### PR TITLE
Fix infinite loop in iteration of result stream

### DIFF
--- a/Ballerina.toml
+++ b/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org= "ballerinax"
 name= "azure_cosmosdb"
-version= "0.1.1"
+version= "0.1.2"
 authors = ["Ballerina"]
 keywords = ["azure", "cosmosdb", "database"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb"

--- a/samples/admin-operations/container/container_operations.bal
+++ b/samples/admin-operations/container/container_operations.bal
@@ -151,10 +151,10 @@ public function main() {
     }
 
     log:printInfo("Getting list of containers");
-    stream<cosmosdb:Container>|error containerList = managementClient->listContainers(databaseId, 2);
+    stream<cosmosdb:Data,error>|error containerList = managementClient->listContainers(databaseId);
 
-    if (containerList is stream<cosmosdb:Container>) {
-        error? e = containerList.forEach(function (cosmosdb:Container container) {
+    if (containerList is stream<cosmosdb:Data,error>) {
+        error? e = containerList.forEach(function (cosmosdb:Data container) {
             log:printInfo(container.toString());
         });
     } else {

--- a/stream_implementer.bal
+++ b/stream_implementer.bal
@@ -36,7 +36,7 @@ class RecordStream {
     public isolated function next() returns record {| Data value; |}|error? {
         if(self.index < self.currentEntries.length()) {
             record {| Data value; |} singleRecord = {value: self.currentEntries[self.index]};
-            self.index = 1;
+            self.index += 1;
             return singleRecord;
         }
         // This code block is for retrieving the next batch of records when the initial batch is finished.
@@ -113,7 +113,7 @@ class QueryResultStream {
     public isolated function next() returns record {| QueryResult value; |}|error? {
         if(self.index < self.currentEntries.length()) {
             record {| QueryResult value; |} singleRecord = {value: self.currentEntries[self.index]};
-            self.index = 1;
+            self.index += 1;
             return singleRecord;
         }
         // This code block is for retrieving the next batch of records when the initial batch is finished.

--- a/tests/test.bal
+++ b/tests/test.bal
@@ -167,7 +167,9 @@ function testListAllDatabases() {
 
     var result = azureCosmosManagementClient->listDatabases();
     if (result is stream<Data, error>) {
-        test:assertTrue(true);
+        error? e = result.forEach(isolated function (Data queryResult) {
+            log:printInfo(queryResult.toString());
+        });     
     } else {
         test:assertFail(msg = result.message());
     }
@@ -284,8 +286,10 @@ function testGetAllContainers() {
     log:printInfo("ACTION : getAllContainers()");
 
     var result = azureCosmosManagementClient->listContainers(databaseId);
-    if (result is stream<Data, error>?) {
-        //
+    if (result is stream<Data, error>) {
+        error? e = result.forEach(isolated function (Data queryResult) {
+            log:printInfo(queryResult.toString());
+        }); 
     } else {
         test:assertFail(msg = result.message());
     }
@@ -432,7 +436,9 @@ function testGetDocumentList() {
 
     var result = azureCosmosClient->getDocumentList(databaseId, containerId);
     if (result is stream<Data, error>) {
-        //
+        error? e = result.forEach(isolated function (Data queryResult) {
+            log:printInfo(queryResult.toString());
+        }); 
     } else {
         test:assertFail(msg = result.message());
     }
@@ -453,7 +459,9 @@ function testGetDocumentListWithRequestOptions() {
     };
     var result = azureCosmosClient->getDocumentList(databaseId, containerId, options);
     if (result is stream<Data, error>) {
-        //    
+        error? e = result.forEach(isolated function (Data queryResult) {
+            log:printInfo(queryResult.toString());
+        }); 
     } else {
         test:assertFail(msg = result.message());
     }
@@ -509,7 +517,9 @@ function testQueryDocuments() {
 
     var result = azureCosmosClient->queryDocuments(databaseId, containerId, query, options);
     if (result is stream<QueryResult, error>) {
-        //
+        error? e = result.forEach(isolated function (QueryResult queryResult) {
+            log:printInfo(queryResult.toString());
+        }); 
     } else {
         test:assertFail(msg = result.message());
     }
@@ -530,7 +540,9 @@ function testQueryDocumentsWithRequestOptions() {
 
     var result = azureCosmosClient->queryDocuments(databaseId, containerId, query, options);
     if (result is stream<QueryResult, error>) {
-        //
+        error? e = result.forEach(isolated function (QueryResult queryResult) {
+            log:printInfo(queryResult.toString());
+        }); 
     } else {
         test:assertFail(msg = result.message());
     }
@@ -627,7 +639,9 @@ function testGetAllStoredProcedures() {
 
     var result = azureCosmosClient->listStoredProcedures(databaseId, containerId);
     if (result is stream<Data, error>) {
-        //
+        error? e = result.forEach(isolated function (Data queryResult) {
+            log:printInfo(queryResult.toString());
+        }); 
     } else {
         test:assertFail(msg = result.message());
     }
@@ -713,7 +727,9 @@ function testListAllUDF() {
 
     var result = azureCosmosManagementClient->listUserDefinedFunctions(databaseId, containerId);
     if (result is stream<Data, error>) {
-        //
+        error? e = result.forEach(isolated function (Data queryResult) {
+            log:printInfo(queryResult.toString());
+        });    
     } else {
         test:assertFail(msg = result.message());
     }
@@ -836,7 +852,9 @@ function testListTriggers() {
 
     var result = azureCosmosManagementClient->listTriggers(databaseId, containerId);
     if (result is stream<Data, error>) {
-        //
+        error? e = result.forEach(isolated function (Data queryResult) {
+            log:printInfo(queryResult.toString());
+        }); 
     } else {
         test:assertFail(msg = result.message());
     }
@@ -922,7 +940,9 @@ function testListUsers() {
 
     var result = azureCosmosManagementClient->listUsers(databaseId);
     if (result is stream<Data, error>) {
-        //
+        error? e = result.forEach(isolated function (Data queryResult) {
+            log:printInfo(queryResult.toString());
+        }); 
     } else {
         test:assertFail(msg = result.message());
     }
@@ -1027,7 +1047,9 @@ function testListPermissions() {
 
     var result = azureCosmosManagementClient->listPermissions(databaseId, newUserId);
     if (result is stream<Data, error>) {
-        //
+        error? e = result.forEach(isolated function (Data queryResult) {
+            log:printInfo(queryResult.toString());
+        }); 
     } else {
         test:assertFail(msg = result.message());
     }


### PR DESCRIPTION
## Purpose
> The `next()` method in the stream implementer interface have a problem in iteration because the increment to the next element is not included.
Resolves https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/issues/7
## Goals
> To fix the bug which will lead to possible infinite loop in accessing the stream and malfunction of the `next()` method.

## Approach
> Include the capability to increment to the next element inside from the `next()` method

## User stories
> A user who use the `forEach()` method of the stream will start to iterate on an infinite loop when there are more than 1 element returned to the stream.

## Documentation
> This change does not change the functionality of the connector but the internal implementation.

## Automation tests
 - Unit tests 
   > Done for all functions
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Ubuntu 20.04 LTS
> Ballerina SL Alpha 4
> JDK 11
 