### PR TITLE
Add weekly build

### DIFF
--- a/.github/workflows/weekly-build.yml
+++ b/.github/workflows/weekly-build.yml
@@ -1,9 +1,9 @@
-name: Daily build
+name: Weekly build
 
 # Controls when the action will run.
 on: 
   schedule:
-    - cron: '30 2 * * *'
+    - cron: '15 2 * * 1'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -40,17 +40,8 @@ jobs:
               uses: ballerina-platform/ballerina-action/@nightly
               with:
                   args:
-                      build -c --skip-tests ./cosmosdb
+                      build -c ./cosmosdb
               env:
                 JAVA_HOME: /usr/lib/jvm/default-jvm
                 BASE_URL: ${{ secrets.BASE_URL }}
                 MASTER_OR_RESOURCE_TOKEN: ${{ secrets.MASTER_OR_RESOURCE_TOKEN }}
-
-            # Publish Github Package
-            - name: Publish Github Package
-              env:
-                packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
-                packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
-                JAVA_OPTS: -DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true
-              run: |
-                ./gradlew publish


### PR DESCRIPTION
## Purpose
Fix https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/issues/10

## Goals

- Skip tests in the daily build
- Add weekly build on Mondays with test

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 11
Swan Lake Beta1