### PR TITLE
[SL Alpha 5] Change the streams to return individual types 

### DIFF
--- a/Ballerina.toml
+++ b/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org= "ballerinax"
 name= "azure_cosmosdb"
-version= "0.1.4"
+version= "0.1.5"
 authors = ["Ballerina"]
 keywords = ["azure", "cosmosdb", "database"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb"

--- a/Dependencies.toml
+++ b/Dependencies.toml
@@ -37,3 +37,5 @@ version = "1.1.0-alpha8"
 org = "ballerina"
 name = "os"
 version = "0.8.0-alpha8"
+
+

--- a/Package.md
+++ b/Package.md
@@ -200,11 +200,11 @@ public function main() {
     string selectAllQuery = string `SELECT * FROM ${containerId.toString()} f WHERE f.gender = ${0}`;
     cosmosdb:ResourceQueryOptions options = {partitionKey : 0, enableCrossPartition: false};
 
-    stream<cosmosdb:QueryResult, error>|error result = azureCosmosClient->queryDocuments(<DATABASE_ID>, <CONTAINER_ID>, 
+    stream<cosmosdb:Document, error>|error result = azureCosmosClient->queryDocuments(<DATABASE_ID>, <CONTAINER_ID>, 
         selectAllQuery, options);
 
-    if (result is stream<cosmosdb:QueryResult, error>) {
-        error? e = result.forEach(function (cosmosdb:QueryResult queryResult) {
+    if (result is stream<cosmosdb:Document, error>) {
+        error? e = result.forEach(function (cosmosdb:Document queryResult) {
             log:printInfo(queryResult.toString());
         });
         log:printInfo("Success!");

--- a/README.md
+++ b/README.md
@@ -188,9 +188,9 @@ For listing the existing documents inside this Cosmos container you have to give
 parameters. Here, you will get a stream of `Document` records as the response. Using the ballerina Stream API you can 
 access the returned results.
 ```ballerina
-stream<cosmosdb:Data, error>|error result = azureCosmosClient->listTriggers("my_database", "my_container");
-if (result is stream<cosmosdb:Data, error>) {
-    error? e = result.forEach(function (cosmosdb:Data document) {
+stream<cosmosdb:Document, error>|error result = azureCosmosClient->listTriggers("my_database", "my_container");
+if (result is stream<cosmosdb:Document, error>) {
+    error? e = result.forEach(function (cosmosdb:Document document) {
         log:printInfo(document.toString());
     });
     log:printInfo("Success!");
@@ -209,11 +209,11 @@ https://docs.microsoft.com/en-us/rest/api/cosmos-db/querying-cosmosdb-resources-
 string selectAllQuery = string `SELECT * FROM ${containerId.toString()} f WHERE f.gender = ${0}`;
 cosmosdb:ResourceQueryOptions options = {partitionKey : 0, enableCrossPartition: false};
 
-stream<cosmosdb:QueryResult, error>|error result = azureCosmosClient->queryDocuments("my_database", "my_container", 
+stream<cosmosdb:Document, error>|error result = azureCosmosClient->queryDocuments("my_database", "my_container", 
     selectAllQuery, options);
 
-if (result is stream<cosmosdb:QueryResult, error>) {
-    error? e = result.forEach(function (cosmosdb:QueryResult queryResult) {
+if (result is stream<cosmosdb:Document, error>) {
+    error? e = result.forEach(function (cosmosdb:Document queryResult) {
         log:printInfo(queryResult.toString());
     });
     log:printInfo("Success!");
@@ -482,10 +482,10 @@ public function main() {
     string containerId = "my_container";
 
     log:printInfo("Getting list of documents");
-    stream<cosmosdb:Data, error>|error result = azureCosmosClient->getDocumentList(databaseId, containerId);
+    stream<cosmosdb:Document, error>|error result = azureCosmosClient->getDocumentList(databaseId, containerId);
 
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data document) {
+    if (result is stream<cosmosdb:Document, error>) {
+        error? e = result.forEach(function (cosmosdb:Document document) {
             log:printInfo(document.toString());
         });
         log:printInfo("Success!");
@@ -575,11 +575,11 @@ public function main() {
     string selectAllQuery = string `SELECT * FROM ${containerId.toString()} f WHERE f.gender = ${0}`;
 
     cosmosdb:ResourceQueryOptions options = {partitionKey : 0, enableCrossPartition: false};
-    stream<cosmosdb:QueryResult, error>|error result = azureCosmosClient->queryDocuments(databaseId, containerId, 
+    stream<cosmosdb:Document, error>|error result = azureCosmosClient->queryDocuments(databaseId, containerId, 
         selectAllQuery, options);
 
-    if (result is stream<cosmosdb:QueryResult, error>) {
-        error? e = result.forEach(function (cosmosdb:QueryResult queryResult) {
+    if (result is stream<cosmosdb:Document, error>) {
+        error? e = result.forEach(function (cosmosdb:Document queryResult) {
             log:printInfo(queryResult.toString());
         });
         log:printInfo("Success!");
@@ -719,10 +719,10 @@ public function main() {
     string containerId = "my_container";
 
     log:printInfo("List stored procedure");
-    stream<cosmosdb:Data, error>?|error result = azureCosmosClient->listStoredProcedures(databaseId, containerId);
-    if (result is stream<cosmosdb:Data, error>?) {
-        if (result is stream<cosmosdb:Data, error>) {
-            error? e = result.forEach(function (cosmosdb:Data storedPrcedure) {
+    stream<cosmosdb:StoredProcedure, error>?|error result = azureCosmosClient->listStoredProcedures(databaseId, containerId);
+    if (result is stream<cosmosdb:StoredProcedure, error>?) {
+        if (result is stream<cosmosdb:StoredProcedure, error>) {
+            error? e = result.forEach(function (cosmosdb:StoredProcedure storedPrcedure) {
                 log:printInfo(storedPrcedure.toString());
             });
             log:printInfo("Success!");
@@ -936,10 +936,10 @@ cosmosdb:ManagementClient managementClient = check new (config);
 
 public function main() {
     log:printInfo("Getting list of databases");
-    stream<cosmosdb:Data, error>|error result = managementClient->listDatabases();
+    stream<cosmosdb:Database, error>|error result = managementClient->listDatabases();
 
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data database) {
+    if (result is stream<cosmosdb:Database, error>) {
+        error? e = result.forEach(function (cosmosdb:Database database) {
             log:printInfo(database.toString());
         });
         log:printInfo("Success!");
@@ -1088,10 +1088,10 @@ public function main() {
     string databaseId = "my_database";
 
     log:printInfo("Getting list of containers");   
-    stream<cosmosdb:Data, error>|error result = managementClient->listContainers(databaseId);
+    stream<cosmosdb:Container, error>|error result = managementClient->listContainers(databaseId);
 
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data container) {
+    if (result is stream<cosmosdb:Container, error>) {
+        error? e = result.forEach(function (cosmosdb:Container container) {
             log:printInfo(container.toString());
         });
         log:printInfo("Success!");
@@ -1263,10 +1263,10 @@ public function main() {
     string containerId = "my_container";
 
     log:printInfo("List  user defined functions");
-    stream<cosmosdb:Data, error>|error result = managementClient->listUserDefinedFunctions(databaseId, containerId);
+    stream<cosmosdb:UserDefinedFunction, error>|error result = managementClient->listUserDefinedFunctions(databaseId, containerId);
 
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data udf) {
+    if (result is stream<cosmosdb:UserDefinedFunction, error>) {
+        error? e = result.forEach(function (cosmosdb:UserDefinedFunction udf) {
             log:printInfo(udf.toString());
         });
         log:printInfo("Success!");
@@ -1477,10 +1477,10 @@ public function main() {
     string containerId = "my_container";
 
     log:printInfo("List available triggers");
-    stream<cosmosdb:Data, error>|error result = managementClient->listTriggers(databaseId, containerId);
+    stream<cosmosdb:Trigger, error>|error result = managementClient->listTriggers(databaseId, containerId);
 
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data trigger) {
+    if (result is stream<cosmosdb:Trigger, error>) {
+        error? e = result.forEach(function (cosmosdb:Trigger trigger) {
             log:printInfo(trigger.toString());
         });
         log:printInfo("Success!");
@@ -1655,9 +1655,9 @@ public function main() {
     string databaseId = "my_database";
 
     log:printInfo("List users");
-    stream<cosmosdb:Data, error>|error result = managementClient->listUsers(databaseId);
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data storedPrcedure) {
+    stream<cosmosdb:Users, error>|error result = managementClient->listUsers(databaseId);
+    if (result is stream<cosmosdb:Users, error>) {
+        error? e = result.forEach(function (cosmosdb:Users storedPrcedure) {
             log:printInfo(storedPrcedure.toString());
         });
         log:printInfo("Success!");
@@ -1863,10 +1863,10 @@ public function main() {
     string userId = "my_user";
 
     log:printInfo("List permissions");
-    stream<cosmosdb:Data, error>|error result = managementClient->listPermissions(databaseId, userId);
+    stream<cosmosdb:Permission, error>|error result = managementClient->listPermissions(databaseId, userId);
 
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data storedPrcedure) {
+    if (result is stream<cosmosdb:Permission, error>) {
+        error? e = result.forEach(function (cosmosdb:Permission storedPrcedure) {
             log:printInfo(storedPrcedure.toString());
         });
         log:printInfo("Success!");

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ for the container. This is provided by giving **Include** or **Exclude**.
 - **isUpsertRequest** - You can convert the creation of a new document into an upsert request by using this parameter. 
 Must be a boolean value.
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/data-operations/documents/create_document.bal
+[Sample](samples/data-operations/documents/create_document.bal)
 
 ### Replace document
 This sample shows how to replace an existing document inside a container. Similar to document creation but, it replaces 
@@ -412,7 +412,7 @@ in `DocumentReplaceOptions` record type in the connector.
 - **indexingDirective** - This option is to specify whether the document is included in any predefined indexing policy 
 for the container. This is provided by giving **Include** or **Exclude**.
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/data-operations/documents/replace_document.bal
+[Sample](samples/data-operations/documents/replace_document.bal)
 
 ### Get a document
 This sample shows how to get a document by its ID. It returns ta record of type `Document`. Here, you have to provide 
@@ -458,7 +458,7 @@ session-level consistency level is maintained.
 Users must set this level to the same or weaker level than the account’s configured consistency level. More information 
 about CosmosDB consistency levels can be found here: https://docs.microsoft.com/en-us/azure/cosmos-db/consistency-levels
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/data-operations/documents/get_document.bal
+[Sample](samples/data-operations/documents/get_document.bal)
 
 ### List documents
 This sample shows how you can get a list of all the documents. For this operation, you will get a stream of documents 
@@ -505,7 +505,7 @@ session-level consistency level is maintained.
 can be found here: https://docs.microsoft.com/en-us/azure/cosmos-db/change-feed
 - **partitionKeyRangeId** - The partition key range ID for reading data.
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/data-operations/documents/list_documents.bal
+[Sample](samples/data-operations/documents/list_documents.bal)
 
 ### Delete a document
 This sample shows how to delete a document which exists inside a container. You have to specify the *database ID*, 
@@ -546,7 +546,7 @@ connector. They are related to maintaining the consistency and handling concurre
 - **sessionToken** - the client will use a session token internally with each read/query request to ensure that the 
 session-level consistency level is maintained.
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/data-operations/documents/delete_document.bal
+[Sample](samples/data-operations/documents/delete_document.bal)
 
 ### Querying documents
 When executing an SQL query using the connector, there are specific ways you can write the query itself. As specified in 
@@ -604,7 +604,7 @@ Notes: <br/>
 - The optional **maxItemCount** parameter specifies the maximum number of results returned per page. So, in the 
 connector, the user can either get the items on one page or get all the results related to each query.
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/data-operations/documents/query_document.bal
+[Sample](samples/data-operations/documents/query_document.bal)
 
 ## Stored Procedures
 A Stored procedure is a piece of application logic written in JavaScript that is registered and executed against a 
@@ -652,7 +652,7 @@ public function main() {
 }
 ```
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/data-operations/stored-procedure/create_stored_procedure.bal
+[Sample](samples/data-operations/stored-procedure/create_stored_procedure.bal)
 
 ### Replace a stored procedure
 This sample shows how to replace an existing stored procedure. This new stored procedure enhances the capabilities of 
@@ -696,7 +696,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/data-operations/stored-procedure/replace_stored_procedure.bal
+[Sample](samples/data-operations/stored-procedure/replace_stored_procedure.bal)
 
 ### List stored procedures
 From this sample, you can get a list of all the stored procedures inside a container. Each record in the result list will 
@@ -735,7 +735,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/data-operations/stored-procedure/list_stored_procedure.bal
+[Sample](samples/data-operations/stored-procedure/list_stored_procedure.bal)
 
 ### Delete a stored procedure
 This sample shows how to delete a stored procedure that exists inside a container. You have to specify the 
@@ -768,7 +768,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/data-operations/stored-procedure/delete_stored_procedure.bal
+[Sample](samples/data-operations/stored-procedure/delete_stored_procedure.bal)
 
 ### Execute a stored procedure
 A stored procedure is a piece of logic written in JavaScript which can be executed via an API call. CosmosDB connector 
@@ -813,7 +813,7 @@ Note: <br/> If a stored procedure contains function arguments to be passed to it
 the `parameters` field of record type `StoredProcedureOptions`. For example, if only one parameter is in the JavaScript 
 function, the argument must be an array with one element as shown in the above sample.
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/data-operations/stored-procedure/execute_stored_procedure.bal
+[Sample](samples/data-operations/stored-procedure/execute_stored_procedure.bal)
 
 ## Management Plane Operations
 ## Databases
@@ -883,7 +883,7 @@ accounts. For the account type which is called **serverless(preview)** you canno
 not providing support for provisioned throughput for containers or databases inside it.
 More information about serverless accounts can be found here: https://docs.microsoft.com/en-us/azure/cosmos-db/serverless
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/database/create_database.bal
+[Sample](samples/admin-operations/database/create_database.bal)
 
 ### Get a database
 This operation is related to reading information about a database that is already created inside the Cosmos DB account. 
@@ -916,7 +916,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/database/get_a_database.bal
+[Sample](samples/admin-operations/database/get_a_database.bal)
 
 ### List All databases
 When there is a need to list down all the databases available inside a Cosmos DB account. This operation will return a 
@@ -949,7 +949,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/database/list_databases.bal
+[Sample](samples/admin-operations/database/list_databases.bal)
 
 ### Delete a database
 This operation can be used for deleting a database inside an Azure Cosmos DB account. It returns a record of type 
@@ -981,7 +981,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/database/delete_database.bal
+[Sample](samples/admin-operations/database/delete_database.bal)
 
 ## Containers
 A container in Cosmos DB is schema-agnostic and it is a unit of scalability for the Cosmos DB. It is horizontally 
@@ -1033,7 +1033,7 @@ More information about indexing can be found here: https://docs.microsoft.com/en
 - **throughputOption** - is used in the creation of a container to configure a throughputOption which is an integer value or a 
 record type.
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/container/create_container.bal
+[Sample](samples/admin-operations/container/create_container.bal)
 ### Get a container
 This operation is related to reading information about a container that is already created inside a database. It mainly 
 returns a record type `Container` which contains the ID of the container, The indexing policy, and the partition key 
@@ -1066,7 +1066,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/container/get_container.bal
+[Sample](samples/admin-operations/container/get_container.bal)
 
 ### List all containers
 When there is a need to list-down all the containers available inside a database. This operation will return a 
@@ -1105,7 +1105,7 @@ Notes: <br/> The optional parameter `maxItemCount` can be provided as an int to 
 This item count decides the number of items returned per page. If this is not specified the number to return will be 
 100 records per page by default.
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/container/list_containers.bal
+[Sample](samples/admin-operations/container/list_containers.bal)
 
 ### Delete a container
 This operation can be used for deleting a container inside a database. It returns `DeleteResponse` if the container is 
@@ -1139,7 +1139,7 @@ public function main() {
 }
 ```
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/container/delete_container.bal
+[Sample](samples/admin-operations/container/delete_container.bal)
 
 ## User Defined Functions
 User-Defined Function - is a side-effect-free piece of application logic written in JavaScript. They can be used to 
@@ -1192,7 +1192,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/user-defined-functions/create_udf.bal
+[Sample](samples/admin-operations/user-defined-functions/create_udf.bal)
 
 ### Replace a user defined function
 This sample shows how you can replace an existing user defined function with a new one. Here, the name of the User 
@@ -1239,7 +1239,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/user-defined-functions/replace_udf.bal
+[Sample](samples/admin-operations/user-defined-functions/replace_udf.bal)
 
 ### List user defined functions
 From this sample, you can get a list of all the user defined functions inside a container. The result will 
@@ -1276,7 +1276,7 @@ public function main() {
 }
 ```
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/user-defined-functions/list_udf.bal
+[Sample](samples/admin-operations/user-defined-functions/list_udf.bal)
 
 ### Delete a user defined function
 This sample shows how to delete a user defined function which exists inside a container. You have to specify the 
@@ -1310,7 +1310,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/user-defined-functions/delete_udf.bal
+[Sample](samples/admin-operations/user-defined-functions/delete_udf.bal)
 
 ## Triggers
 A Trigger is a piece of application logic that can be executed before (pre-triggers) and after (post-triggers). You can 
@@ -1388,7 +1388,7 @@ Notes: <br/> When creating a trigger, there are several required parameters we h
 - **triggerType** - Specifies when the trigger will be fired, **Pre** or **Post**.
 - **triggerFunction** - The function which will be fired when the trigger is executed.
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/triggers/create_trigger.bal
+[Sample](samples/admin-operations/triggers/create_trigger.bal)
 
 ### Replace a trigger
 This sample shows how you can replace an existing trigger with a new one. Here, the name of the trigger is updated to a 
@@ -1455,7 +1455,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/triggers/replace_trigger.bal
+[Sample](samples/admin-operations/triggers/replace_trigger.bal)
 
 ### List triggers
 From this sample, you can get a list of all the triggers inside a container. It will return a stream, which contains 
@@ -1489,7 +1489,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/triggers/list_trigger.bal
+[Sample](samples/admin-operations/triggers/list_trigger.bal)
 
 ### Delete a trigger
 This sample shows how to delete a trigger that exists inside a container. You have to specify the *database ID*, 
@@ -1523,7 +1523,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/triggers/delete_trigger.bal
+[Sample](samples/admin-operations/triggers/delete_trigger.bal)
 
 ## Users
 User management operations in Cosmos DB are strictly related with the **Master Key/Primary Key** of the Cosmos DB account. 
@@ -1565,7 +1565,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/users-permissions/user/create_user.bal
+[Sample](samples/admin-operations/users-permissions/user/create_user.bal)
 
 ### Replace user's ID
 From this sample, you can replace the ID of an existing user. The only replaceable property is the ID of a user created 
@@ -1600,7 +1600,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/users-permissions/user/replace_user_id.bal
+[Sample](samples/admin-operations/users-permissions/user/replace_user_id.bal)
 
 ### Get a user
 From this sample, you can get the basic information about a created user. For this, the *database ID* where the user is 
@@ -1633,7 +1633,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/users-permissions/user/get_user.bal
+[Sample](samples/admin-operations/users-permissions/user/get_user.bal)
 
 ### List users
 From this operation, you can get a list of all the users who are scoped into a given database. It will return a stream, 
@@ -1666,7 +1666,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/users-permissions/user/list_users.bal
+[Sample](samples/admin-operations/users-permissions/user/list_users.bal)
 
 ### Delete a user
 The Common User management operations of databases usually have the option to delete an existing user. The Cosmos DB 
@@ -1699,7 +1699,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/users-permissions/user/delete_user.bal
+[Sample](samples/admin-operations/users-permissions/user/delete_user.bal)
 
 ## Permissions
 Permissions are related to the Users in the Cosmos DB. The person who possesses the **Master-Token** of the Cosmos DB 
@@ -1766,7 +1766,7 @@ The **validityPeriodInSeconds** argument can be provided as the last parameter o
 for the token you are creating. This will override the default validity period of the token. The **maximum** override value 
 is **18000 seconds**.
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/users-permissions/permission/create_permission.bal
+[Sample](samples/admin-operations/users-permissions/permission/create_permission.bal)
 
 ### Replace a permission
 This operation has all the parameters similar to create permission. The only difference is that it only replaces 
@@ -1806,7 +1806,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/users-permissions/permission/replace_permission.bal
+[Sample](samples/admin-operations/users-permissions/permission/replace_permission.bal)
 
 ### Get a permission
 From this sample, you can get the basic information about a created permission. For this, the *database ID* and the 
@@ -1840,7 +1840,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/users-permissions/permission/get_permission.bal
+[Sample](samples/admin-operations/users-permissions/permission/get_permission.bal)
 
 ### List permissions
 From this operation, you can get a list of all the permissions that belong to a single user. It will return a stream, 
@@ -1875,7 +1875,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/users-permissions/permission/list_permissions.bal
+[Sample](samples/admin-operations/users-permissions/permission/list_permissions.bal)
 
 ### Delete a permission
 This Operation allows deleting a permission in the database. For deleting the permission, the specific *database ID*, *user ID* to which the permission belongs and the *ID of the Permission* to delete must be provided.
@@ -1907,7 +1907,7 @@ public function main() {
 }
 ```
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/users-permissions/permission/delete_permission.bal
+[Sample](samples/admin-operations/users-permissions/permission/delete_permission.bal)
 
 ## Offers
 Cosmos DB containers have either user-defined performance levels or pre-defined performance levels defined for each of 
@@ -1916,7 +1916,7 @@ them. The operations on offers support replacing existing offers, listing and re
 Note: <br/>Operations on offers are not supported in `Serverless` accounts because they don’t specifically have a 
 predefined throughput level.
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/offers/offer_operations.bal
+[Sample](samples/admin-operations/offers/offer_operations.bal)
 
 # Building from the Source
 ## Setting Up the Prerequisites

--- a/client_endpoint.bal
+++ b/client_endpoint.bal
@@ -184,7 +184,7 @@ public client class DataPlaneClient {
     @display {label: "Query Documents"}
     remote isolated function queryDocuments(@display {label: "Database ID"} string databaseId, 
                                             @display {label: "Container ID"} string containerId, 
-                                            @display {label: "SQL query"} string sqlQuery, 
+                                            @display {label: "SQL Query"} string sqlQuery, 
                                             @display {label: "Optional Header Parameters"} ResourceQueryOptions? 
                                             resourceQueryOptions = ()) returns 
                                             @tainted @display {label: "Stream of Documents"} 

--- a/client_endpoint.bal
+++ b/client_endpoint.bal
@@ -45,9 +45,9 @@ public client class DataPlaneClient {
     # + documentCreateOptions - The `DocumentCreateOptions` which can be used to add additional capabilities to the 
     #                           request
     # + return - If successful, returns `Document`. Else returns `Error`.
-    @display {label: "Create document"}
-    remote isolated function createDocument(@display {label: "Database Name"} string databaseId, 
-                                            @display {label: "Container Name"} string containerId, 
+    @display {label: "Create Document"}
+    remote isolated function createDocument(@display {label: "Database ID"} string databaseId, 
+                                            @display {label: "Container ID"} string containerId, 
                                             @display {label: "Document"} record {|string id; json...;|} document, 
                                             @display {label: "Partition Key"} int|float|decimal|string partitionKey, 
                                             @display {label: "Optional Header Parameters"} DocumentCreateOptions? 
@@ -74,9 +74,9 @@ public client class DataPlaneClient {
     # + documentReplaceOptions - The `DocumentReplaceOptions` which can be used to add additional capabilities to the 
     #                            request
     # + return - If successful, returns a `Document`. Else returns `Error`.
-    @display {label: "Replace document"}
-    remote isolated function replaceDocument(@display {label: "Database Name"} string databaseId, 
-                                             @display {label: "Container Name"} string containerId, 
+    @display {label: "Replace Document"}
+    remote isolated function replaceDocument(@display {label: "Database ID"} string databaseId, 
+                                             @display {label: "Container ID"} string containerId, 
                                              @display {label: "New Document"} @tainted record {|string id; json...;|} 
                                              document, 
                                              @display {label: "Partition Key"} int|float|decimal|string partitionKey,  
@@ -99,14 +99,14 @@ public client class DataPlaneClient {
     # 
     # + databaseId - ID of the database to which the container belongs to
     # + containerId - ID of the container which contains the document
-    # + documentId - Id of the document 
+    # + documentId - ID of the document 
     # + partitionKey - The value of partition key field of the container
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to the request
     # + return - If successful, returns `Document`. Else returns `Error`.
-    @display {label: "Get document"}
-    remote isolated function getDocument(@display {label: "Database Name"} string databaseId, 
-                                         @display {label: "Container Name"} string containerId, 
-                                         @display {label: "Document Id"} string documentId, 
+    @display {label: "Get Document"}
+    remote isolated function getDocument(@display {label: "Database ID"} string databaseId, 
+                                         @display {label: "Container ID"} string containerId, 
+                                         @display {label: "Document ID"} string documentId, 
                                          @display {label: "Partition Key"} int|float|decimal|string partitionKey, 
                                          @display {label: "Optional Header Parameters"} ResourceReadOptions?
                                          resourceReadOptions = ()) returns @tainted Document|Error { 
@@ -128,9 +128,9 @@ public client class DataPlaneClient {
     # + containerId - ID of the container which contains the document
     # + documentListOptions - The `DocumentListOptions` which can be used to add additional capabilities to the request
     # + return - If successful, returns `stream<Data, error>`. Else, returns `Error`. 
-    @display {label: "Get documents"} 
-    remote isolated function getDocumentList(@display {label: "Database Name"} string databaseId, 
-                                             @display {label: "Container Name"} string containerId, 
+    @display {label: "Get Documents"}
+    remote isolated function getDocumentList(@display {label: "Database ID"} string databaseId, 
+                                             @display {label: "Container ID"} string containerId, 
                                              @display {label: "Optional Header Parameters"} DocumentListOptions? 
                                              documentListOptions = ()) returns 
                                              @tainted @display {label: "Stream of Documents"} stream<Data, error>|Error { 
@@ -154,10 +154,10 @@ public client class DataPlaneClient {
     # + resourceDeleteOptions - The `ResourceDeleteOptions` which can be used to add additional capabilities to the 
     #                           request
     # + return - If successful, returns `DeleteResponse`. Else returns `Error`.
-    @display {label: "Delete document"}
-    remote isolated function deleteDocument(@display {label: "Database Name"} string databaseId, 
-                                            @display {label: "Container Name"} string containerId, 
-                                            @display {label: "Document Id"} string documentId, 
+    @display {label: "Delete Document"}
+    remote isolated function deleteDocument(@display {label: "Database ID"} string databaseId, 
+                                            @display {label: "Container ID"} string containerId, 
+                                            @display {label: "Document ID"} string documentId, 
                                             @display {label: "Partition Key"} int|float|decimal|string partitionKey, 
                                             @display {label: "Optional Header Parameters"} ResourceDeleteOptions? 
                                             resourceDeleteOptions = ()) returns @tainted DeleteResponse|Error { 
@@ -181,9 +181,9 @@ public client class DataPlaneClient {
     # + resourceQueryOptions - The `ResourceQueryOptions` which can be used to add additional capabilities to the 
     #                          request
     # + return - If successful, returns a `stream<QueryResult, error>`. Else returns `Error`.
-    @display {label: "Query documents"}
-    remote isolated function queryDocuments(@display {label: "Database Name"} string databaseId, 
-                                            @display {label: "Container Name"} string containerId, 
+    @display {label: "Query Documents"}
+    remote isolated function queryDocuments(@display {label: "Database ID"} string databaseId, 
+                                            @display {label: "Container ID"} string containerId, 
                                             @display {label: "SQL query"} string sqlQuery, 
                                             @display {label: "Optional Header Parameters"} ResourceQueryOptions? 
                                             resourceQueryOptions = ()) returns 
@@ -216,10 +216,10 @@ public client class DataPlaneClient {
     # + storedProcedureId - A unique ID for the newly created stored procedure
     # + storedProcedure - A JavaScript function represented as a string
     # + return - If successful, returns a `StoredProcedure`. Else returns `Error`. 
-    @display {label: "Create stored procedure"}
-    remote isolated function createStoredProcedure(@display {label: "Database Name"} string databaseId,
-                                                   @display {label: "Container Name"} string containerId,
-                                                   @display {label: "Stored Procedure Id"} string storedProcedureId,
+    @display {label: "Create Stored Procedure"}
+    remote isolated function createStoredProcedure(@display {label: "Database ID"} string databaseId,
+                                                   @display {label: "Container ID"} string containerId,
+                                                   @display {label: "Stored Procedure ID"} string storedProcedureId,
                                                    @display {label: "Stored Procedure Function"} string storedProcedure)
                                                    returns @tainted StoredProcedure|Error {
         http:Request request = new;
@@ -245,10 +245,10 @@ public client class DataPlaneClient {
     # + storedProcedureId - The ID of the stored procedure to be replaced
     # + storedProcedure - A JavaScript function which will replace the existing one
     # + return - If successful, returns a `StoredProcedure`. Else returns `Error`. 
-    @display {label: "Replace stored procedure"} 
-    remote isolated function replaceStoredProcedure(@display {label: "Database Name"} string databaseId, 
-                                                    @display {label: "Container Name"} string containerId, 
-                                                    @display {label: "Stored Procedure Id"} string storedProcedureId, 
+    @display {label: "Replace Stored Procedure"}
+    remote isolated function replaceStoredProcedure(@display {label: "Database ID"} string databaseId, 
+                                                    @display {label: "Container ID"} string containerId, 
+                                                    @display {label: "Stored Procedure ID"} string storedProcedureId, 
                                                     @display {label: "Stored Procedure Function"} string storedProcedure) 
                                                     returns @tainted StoredProcedure|Error { 
         http:Request request = new;
@@ -273,9 +273,9 @@ public client class DataPlaneClient {
     # + containerId - ID of the container which contains the stored procedures
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to the request
     # + return - If successful, returns a `stream<Data, error>`. Else returns `Error`. 
-    @display {label: "Get stored procedures"} 
-    remote isolated function listStoredProcedures(@display {label: "Database Name"} string databaseId, 
-                                                  @display {label: "Container Name"} string containerId, 
+    @display {label: "Get Stored Procedures"}
+    remote isolated function listStoredProcedures(@display {label: "Database ID"} string databaseId, 
+                                                  @display {label: "Container ID"} string containerId, 
                                                   @display {label: "Optional Header Parameters"} ResourceReadOptions?
                                                   resourceReadOptions = ()) returns 
                                                   @tainted @display {label: "Stream of Stored Procedures"} 
@@ -300,10 +300,10 @@ public client class DataPlaneClient {
     # + resourceDeleteOptions - The `ResourceDeleteOptions` which can be used to add additional capabilities to the 
     #                           request
     # + return - If successful, returns `DeleteResponse`. Else returns `Error`.
-    @display {label: "Delete stored procedure"} 
-    remote isolated function deleteStoredProcedure(@display {label: "Database Name"} string databaseId, 
-                                                   @display {label: "Container Name"} string containerId, 
-                                                   @display {label: "Stored Procedure Id"} string storedProcedureId, 
+    @display {label: "Delete Stored Procedure"}
+    remote isolated function deleteStoredProcedure(@display {label: "Database ID"} string databaseId, 
+                                                   @display {label: "Container ID"} string containerId, 
+                                                   @display {label: "Stored Procedure ID"} string storedProcedureId, 
                                                    @display {label: "Optional Header Parameters"} ResourceDeleteOptions? 
                                                    resourceDeleteOptions = ()) returns @tainted DeleteResponse|Error { 
         http:Request request = new;
@@ -325,10 +325,10 @@ public client class DataPlaneClient {
     # + storedProcedureExecuteOptions - A record of type `StoredProcedureExecuteOptions` to specify the additional 
     #                            parameters
     # + return - If successful, returns `json` with the output from the executed function. Else returns `Error`. 
-    @display {label: "Execute stored procedure"} 
-    remote isolated function executeStoredProcedure(@display {label: "Database Name"} string databaseId, 
-                                                    @display {label: "Container Name"} string containerId, 
-                                                    @display {label: "Stored Procedure Id"} string storedProcedureId, 
+    @display {label: "Execute Stored Procedure"}
+    remote isolated function executeStoredProcedure(@display {label: "Database ID"} string databaseId, 
+                                                    @display {label: "Container ID"} string containerId, 
+                                                    @display {label: "Stored Procedure ID"} string storedProcedureId, 
                                                     @display {label: "Execution Options"} 
                                                     StoredProcedureExecuteOptions storedProcedureExecuteOptions) 
                                                     returns @tainted @display {label: "JSON Response"} json|Error { 

--- a/client_endpoint.bal
+++ b/client_endpoint.bal
@@ -127,21 +127,21 @@ public client class DataPlaneClient {
     # + databaseId - ID of the database to which the container belongs to
     # + containerId - ID of the container which contains the document
     # + documentListOptions - The `DocumentListOptions` which can be used to add additional capabilities to the request
-    # + return - If successful, returns `stream<Data, error>`. Else, returns `Error`. 
+    # + return - If successful, returns `stream<Document, error>`. Else, returns `Error`. 
     @display {label: "Get Documents"}
     remote isolated function getDocumentList(@display {label: "Database ID"} string databaseId, 
                                              @display {label: "Container ID"} string containerId, 
                                              @display {label: "Optional Header Parameters"} DocumentListOptions? 
                                              documentListOptions = ()) returns 
-                                             @tainted @display {label: "Stream of Documents"} stream<Data, error>|Error { 
+                                             @tainted @display {label: "Stream of Documents"} stream<Document, error>|Error { 
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId, 
             RESOURCE_TYPE_DOCUMENTS]);
         map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET, 
             requestPath);
         headerMap = setOptionalGetHeaders(headerMap, documentListOptions);
 
-        RecordStream objectInstance = check new (self.httpClient, requestPath, headerMap);
-        stream<Data, error> finalStream = new (objectInstance);
+        DocumentStream objectInstance = check new (self.httpClient, requestPath, headerMap);
+        stream<Document, error> finalStream = new (objectInstance);
         return finalStream;
     }
 
@@ -180,7 +180,7 @@ public client class DataPlaneClient {
     # + sqlQuery - A string containing the SQL query
     # + resourceQueryOptions - The `ResourceQueryOptions` which can be used to add additional capabilities to the 
     #                          request
-    # + return - If successful, returns a `stream<QueryResult, error>`. Else returns `Error`.
+    # + return - If successful, returns a `stream<Document, error>`. Else returns `Error`.
     @display {label: "Query Documents"}
     remote isolated function queryDocuments(@display {label: "Database ID"} string databaseId, 
                                             @display {label: "Container ID"} string containerId, 
@@ -188,7 +188,7 @@ public client class DataPlaneClient {
                                             @display {label: "Optional Header Parameters"} ResourceQueryOptions? 
                                             resourceQueryOptions = ()) returns 
                                             @tainted @display {label: "Stream of Documents"} 
-                                            stream<QueryResult, error>|Error { 
+                                            stream<Document, error>|Error { 
         http:Request request = new;
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId,
             RESOURCE_TYPE_DOCUMENTS]);
@@ -203,8 +203,8 @@ public client class DataPlaneClient {
         request.setJsonPayload(<@untainted>payload);
 
         check setHeadersForQuery(request);
-        QueryResultStream objectInstance = check new (self.httpClient, requestPath, request);
-        stream<QueryResult, error> finalStream = new (objectInstance);
+        DocumentQueryResultStream objectInstance = check new (self.httpClient, requestPath, request);
+        stream<Document, error> finalStream = new (objectInstance);
         return finalStream;
     }
 
@@ -272,14 +272,14 @@ public client class DataPlaneClient {
     # + databaseId - ID of the database to which the container belongs to
     # + containerId - ID of the container which contains the stored procedures
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to the request
-    # + return - If successful, returns a `stream<Data, error>`. Else returns `Error`. 
+    # + return - If successful, returns a `stream<StoredProcedure, error>`. Else returns `Error`. 
     @display {label: "Get Stored Procedures"}
     remote isolated function listStoredProcedures(@display {label: "Database ID"} string databaseId, 
                                                   @display {label: "Container ID"} string containerId, 
                                                   @display {label: "Optional Header Parameters"} ResourceReadOptions?
                                                   resourceReadOptions = ()) returns 
                                                   @tainted @display {label: "Stream of Stored Procedures"} 
-                                                  stream<Data, error>|Error { 
+                                                  stream<StoredProcedure, error>|Error { 
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId, 
             RESOURCE_TYPE_STORED_POCEDURES]);
         
@@ -287,8 +287,8 @@ public client class DataPlaneClient {
             requestPath);
         headerMap = setOptionalGetHeaders(headerMap, resourceReadOptions);
 
-        RecordStream objectInstance = check new (self.httpClient, requestPath, headerMap);
-        stream<Data, error> finalStream = new (objectInstance);
+        StoredProcedureStream objectInstance = check new (self.httpClient, requestPath, headerMap);
+        stream<StoredProcedure, error> finalStream = new (objectInstance);
         return finalStream;
     }
 

--- a/management_endpoint.bal
+++ b/management_endpoint.bal
@@ -38,8 +38,8 @@ public client class ManagementClient {
     # + databaseId - ID of the new database. Must be a unique value.
     # + throughputOption - Optional. Throughput parameter of type int or json.
     # + return - If successful, returns `Database`. Else returns `Error`.
-    @display {label: "Create database"} 
-    remote isolated function createDatabase(@display {label: "Database Name"} string databaseId, 
+    @display {label: "Create Database"} 
+    remote isolated function createDatabase(@display {label: "Database ID"} string databaseId, 
                                             @display {label: "Maximum Throughput (optional)"} 
                                             (int|record{|int maxThroughput;|})? throughputOption = ()) 
                                             returns @tainted Database|Error {
@@ -66,8 +66,8 @@ public client class ManagementClient {
     # + databaseId - ID of the new database. Must be a unique value.
     # + throughputOption - Optional. Throughput parameter of type int or json.
     # + return - If successful, returns `Database` or `nil` if database already exists. Else returns `Error`.
-    @display {label: "Create database if does not exist"} 
-    remote isolated function createDatabaseIfNotExist(@display {label: "Database Name"} string databaseId, 
+    @display {label: "Create Database If Not Exist"} 
+    remote isolated function createDatabaseIfNotExist(@display {label: "Database ID"} string databaseId, 
                                                       @display {label: "Maximum Throughput (optional)"} 
                                                       (int|record{|int maxThroughput;|})? throughputOption = ()) returns 
                                                       @tainted Database?|Error {
@@ -85,8 +85,8 @@ public client class ManagementClient {
     # + databaseId - ID of the database 
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to the request
     # + return - If successful, returns `Database`. Else returns `Error`.
-    @display {label: "Get database"} 
-    remote isolated function getDatabase(@display {label: "Database Name"} string databaseId, 
+    @display {label: "Get Database"} 
+    remote isolated function getDatabase(@display {label: "Database ID"} string databaseId, 
                                          @display {label: "Optional Header Parameters"} ResourceReadOptions? 
                                          resourceReadOptions = ()) 
                                          returns @tainted Database|Error {
@@ -103,7 +103,7 @@ public client class ManagementClient {
     # List information of all databases.
     # 
     # + return - If successful, returns `stream<Data, error>`. else returns `Error`.
-    @display {label: "Get databases"}  
+    @display {label: "Get Databases"}  
     remote isolated function listDatabases() returns 
                                           @tainted @display {label: "Stream of Databases"} stream<Data, error>|Error {
         http:Request request = new;
@@ -123,8 +123,8 @@ public client class ManagementClient {
     # + resourceDeleteOptions - The `ResourceDeleteOptions` which can be used to add additional capabilities 
     #                           to the request
     # + return - If successful, returns `DeleteResponse`. Else returns `Error`.
-    @display {label: "Delete a database"} 
-    remote isolated function deleteDatabase(@display {label: "Database Name"} string databaseId, 
+    @display {label: "Delete Database"} 
+    remote isolated function deleteDatabase(@display {label: "Database ID"} string databaseId, 
                                             @display {label: "Optional Header Parameters"} ResourceDeleteOptions? 
                                             resourceDeleteOptions = ()) returns @tainted DeleteResponse|Error {
         http:Request request = new;
@@ -145,9 +145,9 @@ public client class ManagementClient {
     # + indexingPolicy - Optional. A record of type `IndexingPolicy`.
     # + throughputOption - Optional. Throughput parameter of type int or json.
     # + return - If successful, returns `Container`. Else returns `Error`.
-    @display {label: "Create container"} 
-    remote isolated function createContainer(@display {label: "Database Name"} string databaseId, 
-                                             @display {label: "Container Name"} string containerId, 
+    @display {label: "Create Container"} 
+    remote isolated function createContainer(@display {label: "Database ID"} string databaseId, 
+                                             @display {label: "Container ID"} string containerId, 
                                              @display {label: "Partition Key Definition"} PartitionKey partitionKey, 
                                              @display {label: "Indexing Policy (optional)"} IndexingPolicy? 
                                              indexingPolicy = (), 
@@ -186,9 +186,9 @@ public client class ManagementClient {
     # + throughputOption - Optional. Throughput parameter of type int or json.
     # + return - If successful, returns `Container` if a new container is created or `nil` if container already exists. 
     #            Else returns `Error`.
-    @display {label: "Create container if not exist"} 
-    remote isolated function createContainerIfNotExist(@display {label: "Database Name"} string databaseId, 
-                                                       @display {label: "Container Name"} string containerId, 
+    @display {label: "Create Container If Not Exist"} 
+    remote isolated function createContainerIfNotExist(@display {label: "Database ID"} string databaseId, 
+                                                       @display {label: "Container ID"} string containerId, 
                                                        @display {label: "Partition Key Definition"} PartitionKey 
                                                        partitionKey, 
                                                        @display {label: "Indexing Policy (optional)"} IndexingPolicy? 
@@ -211,9 +211,9 @@ public client class ManagementClient {
     # + containerId - ID of the container
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to the request
     # + return - If successful, returns `Container`. Else returns `Error`.
-    @display {label: "Get container"} 
-    remote isolated function getContainer(@display {label: "Database Name"} string databaseId, 
-                                          @display {label: "Container Name"} string containerId, 
+    @display {label: "Get Container"} 
+    remote isolated function getContainer(@display {label: "Database ID"} string databaseId, 
+                                          @display {label: "Container ID"} string containerId, 
                                           @display {label: "Optional Header Parameters"} ResourceReadOptions? 
                                           resourceReadOptions = ()) 
                                           returns @tainted Container|Error {
@@ -231,8 +231,8 @@ public client class ManagementClient {
     # 
     # + databaseId - ID of the database to which the containers belongs to
     # + return - If successful, returns `stream<Data, error>`. Else returns `Error`.
-    @display {label: "Get containers"} 
-    remote isolated function listContainers(@display {label: "Database Name"} string databaseId) 
+    @display {label: "Get Containers"} 
+    remote isolated function listContainers(@display {label: "Database ID"} string databaseId) 
                                             returns @tainted @display {label: "Stream of Containers"} 
                                             stream<Data, error>|Error {
         http:Request request = new;
@@ -253,9 +253,9 @@ public client class ManagementClient {
     # + resourceDeleteOptions - The `ResourceDeleteOptions` which can be used to add additional capabilities to the 
     #                           request
     # + return - If successful, returns `DeleteResponse`. Else returns `Error`.
-    @display {label: "Delete container"} 
-    remote isolated function deleteContainer(@display {label: "Database Name"} string databaseId, 
-                                             @display {label: "Container Name"} string containerId, 
+    @display {label: "Delete Container"} 
+    remote isolated function deleteContainer(@display {label: "Database ID"} string databaseId, 
+                                             @display {label: "Container ID"} string containerId, 
                                              @display {label: "Optional Header Parameters"} ResourceDeleteOptions? 
                                              resourceDeleteOptions = ()) returns 
                                              @tainted DeleteResponse|Error {
@@ -274,9 +274,9 @@ public client class ManagementClient {
     # + databaseId - ID of the database to which the container belongs to
     # + containerId - ID of the container where the partition key ranges are related to
     # + return - If successful, returns `stream<Data, error>`. Else returns `Error`.
-    @display {label: "Get partition key ranges"} 
-    remote isolated function listPartitionKeyRanges(@display {label: "Database Name"} string databaseId, 
-                                                    @display {label: "Container Name"} string containerId) returns 
+    @display {label: "Get Partition Key Ranges"} 
+    remote isolated function listPartitionKeyRanges(@display {label: "Database ID"} string databaseId, 
+                                                    @display {label: "Container ID"} string containerId) returns 
                                                     @tainted @display {label: "Stream of Partition Key Ranges"} 
                                                     stream<Data, error>|Error {
         http:Request request = new;
@@ -290,18 +290,18 @@ public client class ManagementClient {
         return finalStream;
     }
 
-    # Create a new user defined function. A user defined function is a side effect free piece of application logic 
+    # Create a new User Defined Function. A User Defined Function is a side effect free piece of application logic 
     # written in JavaScript. 
     # 
     # + databaseId - ID of the database to which the container belongs to
-    # + containerId - ID of the container where, user defined function is created
-    # + userDefinedFunctionId - A unique ID for the newly created user defined function
+    # + containerId - ID of the container where, User Defined Function is created
+    # + userDefinedFunctionId - A unique ID for the newly created User Defined Function
     # + userDefinedFunction - A JavaScript function represented as a string
     # + return - If successful, returns a `UserDefinedFunction`. Else returns `Error`. 
-    @display {label: "Create user defined function"} 
-    remote isolated function createUserDefinedFunction(@display {label: "Database Name"} string databaseId, 
-                                                       @display {label: "Container Name"} string containerId, 
-                                                       @display {label: "User Defined Function Id"} string 
+    @display {label: "Create User Defined Function"} 
+    remote isolated function createUserDefinedFunction(@display {label: "Database ID"} string databaseId, 
+                                                       @display {label: "Container ID"} string containerId, 
+                                                       @display {label: "User Defined Function ID"} string 
                                                        userDefinedFunctionId, 
                                                        @display {label: "User Defined Function"} string 
                                                        userDefinedFunction) returns 
@@ -322,17 +322,17 @@ public client class ManagementClient {
         return mapJsonToUserDefinedFunction(jsonResponse);
     }
 
-    # Replace an existing user defined function.
+    # Replace an existing User Defined Function.
     # 
     # + databaseId - ID of the database to which the container belongs to
-    # + containerId - ID of the container which contains the existing user defined function
-    # + userDefinedFunctionId - The ID of the user defined function to replace
+    # + containerId - ID of the container which contains the existing User Defined Function
+    # + userDefinedFunctionId - The ID of the User Defined Function to replace
     # + userDefinedFunction - A JavaScript function represented as a string
     # + return - If successful, returns a `UserDefinedFunction`. Else returns `Error`.
-    @display {label: "Replace user defined function"} 
-    remote isolated function replaceUserDefinedFunction(@display {label: "Database Name"} string databaseId, 
-                                                        @display {label: "Container Name"} string containerId, 
-                                                        @display {label: "User Defined Function Id"} string 
+    @display {label: "Replace User Defined Function"} 
+    remote isolated function replaceUserDefinedFunction(@display {label: "Database ID"} string databaseId, 
+                                                        @display {label: "Container ID"} string containerId, 
+                                                        @display {label: "User Defined Function ID"} string 
                                                         userDefinedFunctionId, 
                                                         @display {label: "User Defined Function"} string 
                                                         userDefinedFunction) returns 
@@ -359,9 +359,9 @@ public client class ManagementClient {
     # + containerId - ID of the container which contains the user defined functions
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to the request
     # + return - If successful, returns a `stream<Data, error>`. Else returns `Error`. 
-    @display {label: "Get user defined functions"} 
-    remote isolated function listUserDefinedFunctions(@display {label: "Database Name"} string databaseId, 
-                                                      @display {label: "Container Name"} string containerId, 
+    @display {label: "Get User Defined Functions"} 
+    remote isolated function listUserDefinedFunctions(@display {label: "Database ID"} string databaseId, 
+                                                      @display {label: "Container ID"} string containerId, 
                                                       @display {label: "Optional Header Parameters"} ResourceReadOptions? 
                                                       resourceReadOptions = ()) returns 
                                                       @tainted @display {label: "Stream of User Defined Fucntions"} 
@@ -378,18 +378,18 @@ public client class ManagementClient {
         return finalStream;
     }
 
-    # Delete an existing user defined function.
+    # Delete an existing User Defined Function.
     # 
     # + databaseId - ID of the database to which the container belongs to
-    # + containerId - ID of the container which contains the user defined function
-    # + userDefinedFunctionid - Id of UDF to delete
+    # + containerId - ID of the container which contains the User Defined Function
+    # + userDefinedFunctionid - ID of UDF to delete
     # + resourceDeleteOptions - The `ResourceDeleteOptions` which can be used to add additional capabilities to the 
     #                           request
     # + return - If successful, returns `DeleteResponse`. Else returns `Error`.
-    @display {label: "Delete user defined function"} 
-    remote isolated function deleteUserDefinedFunction(@display {label: "Database Name"} string databaseId, 
-                                                       @display {label: "Container Name"} string containerId, 
-                                                       @display {label: "User Defined Function Id"} string 
+    @display {label: "Delete User Defined Function"} 
+    remote isolated function deleteUserDefinedFunction(@display {label: "Database ID"} string databaseId, 
+                                                       @display {label: "Container ID"} string containerId, 
+                                                       @display {label: "User Defined Function ID"} string 
                                                        userDefinedFunctionid, 
                                                        @display {label: "Optional Header Parameters"} 
                                                        ResourceDeleteOptions? resourceDeleteOptions =()) returns
@@ -416,10 +416,10 @@ public client class ManagementClient {
     #                      `Delete`
     # + triggerType - The instance in which trigger will be executed `Pre` or `Post`
     # + return - If successful, returns a `Trigger`. Else returns `Error`. 
-    @display {label: "Create trigger"} 
-    remote isolated function createTrigger(@display {label: "Database Name"} string databaseId, 
-                                           @display {label: "Container Name"} string containerId, 
-                                           @display {label: "Trigger Id"} string triggerId, 
+    @display {label: "Create Trigger"} 
+    remote isolated function createTrigger(@display {label: "Database ID"} string databaseId, 
+                                           @display {label: "Container ID"} string containerId, 
+                                           @display {label: "Trigger ID"} string triggerId, 
                                            @display {label: "Trigger"} string trigger, 
                                            @display {label: "Triggering Operation"} TriggerOperation triggerOperation, 
                                            @display {label: "Trigger Type"} TriggerType triggerType) returns 
@@ -451,10 +451,10 @@ public client class ManagementClient {
     # + triggerOperation - The specific operation in which trigger will be executed
     # + triggerType - The instance in which trigger will be executed `Pre` or `Post`
     # + return - If successful, returns a `Trigger`. Else returns `Error`.
-    @display {label: "Replace trigger"} 
-    remote isolated function replaceTrigger(@display {label: "Database Name"} string databaseId, 
-                                            @display {label: "Container Name"} string containerId, 
-                                            @display {label: "Trigger Id"} string triggerId, 
+    @display {label: "Replace Trigger"} 
+    remote isolated function replaceTrigger(@display {label: "Database ID"} string databaseId, 
+                                            @display {label: "Container ID"} string containerId, 
+                                            @display {label: "Trigger ID"} string triggerId, 
                                             @display {label: "Trigger"} string trigger, 
                                             @display {label: "Triggering Operation"} TriggerOperation triggerOperation, 
                                             @display {label: "Trigger Type"} TriggerType triggerType) returns 
@@ -483,9 +483,9 @@ public client class ManagementClient {
     # + containerId - ID of the container which contains the triggers
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to therequest
     # + return - If successful, returns a `stream<Data, error>`. Else returns `Error`. 
-    @display {label: "Get triggers"} 
-    remote isolated function listTriggers(@display {label: "Database Name"} string databaseId, 
-                                          @display {label: "Container Name"} string containerId, 
+    @display {label: "Get Triggers"} 
+    remote isolated function listTriggers(@display {label: "Database ID"} string databaseId, 
+                                          @display {label: "Container ID"} string containerId, 
                                           @display {label: "Optional Header Parameters"} ResourceReadOptions?
                                           resourceReadOptions = ()) returns 
                                           @tainted @display {label: "Stream of Triggers"} stream<Data, error>|Error { 
@@ -509,10 +509,10 @@ public client class ManagementClient {
     # + resourceDeleteOptions - The `ResourceDeleteOptions` which can be used to add additional capabilities to the 
     #                           request
     # + return - If successful, returns `DeleteResponse`. Else returns `Error`.
-    @display {label: "Delete trigger"} 
-    remote isolated function deleteTrigger(@display {label: "Database Name"} string databaseId, 
-                                           @display {label: "Container Name"} string containerId, 
-                                           @display {label: "Trigger Id"} string triggerId, 
+    @display {label: "Delete Trigger"} 
+    remote isolated function deleteTrigger(@display {label: "Database ID"} string databaseId, 
+                                           @display {label: "Container ID"} string containerId, 
+                                           @display {label: "Trigger ID"} string triggerId, 
                                            @display {label: "Optional Header Parameters"} ResourceDeleteOptions? 
                                            resourceDeleteOptions = ()) returns @tainted DeleteResponse|Error {
         http:Request request = new;
@@ -531,9 +531,9 @@ public client class ManagementClient {
     # + databaseId - ID of the database where the user is created.
     # + userId - ID of the new user. Must be a unique value.
     # + return - If successful, returns a `User`. Else returns `Error`.
-    @display {label: "Create user"} 
-    remote isolated function createUser(@display {label: "Database Name"} string databaseId, 
-                                        @display {label: "User Id"} string userId) returns @tainted User|Error {
+    @display {label: "Create User"} 
+    remote isolated function createUser(@display {label: "Database ID"} string databaseId, 
+                                        @display {label: "User ID"} string userId) returns @tainted User|Error {
         http:Request request = new;
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_USER]);
         check setMandatoryHeaders(request, self.host, self.primaryKeyOrResourceToken, http:HTTP_POST, requestPath);
@@ -551,10 +551,10 @@ public client class ManagementClient {
     # + userId - Old ID of the user
     # + newUserId - New ID for the user
     # + return - If successful, returns a `User`. Else returns `Error`.
-    @display {label: "Replace user Id"} 
-    remote isolated function replaceUserId(@display {label: "Database Name"} string databaseId, 
-                                           @display {label: "Old User Id"} string userId, 
-                                           @display {label: "New User Id"} string newUserId) returns 
+    @display {label: "Replace User ID"} 
+    remote isolated function replaceUserId(@display {label: "Database ID"} string databaseId, 
+                                           @display {label: "Old User ID"} string userId, 
+                                           @display {label: "New User ID"} string newUserId) returns 
                                            @tainted User|Error {
         http:Request request = new;
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_USER, userId]);
@@ -574,9 +574,9 @@ public client class ManagementClient {
     # + userId - ID of user
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to the request
     # + return - If successful, returns a `User`. Else returns `Error`.
-    @display {label: "Get user"} 
-    remote isolated function getUser(@display {label: "Database Name"} string databaseId, 
-                                     @display {label: "User Id"} string userId, 
+    @display {label: "Get User"} 
+    remote isolated function getUser(@display {label: "Database ID"} string databaseId, 
+                                     @display {label: "User ID"} string userId, 
                                      @display {label: "Optional Header Parameters"} ResourceReadOptions? 
                                      resourceReadOptions = ()) returns @tainted User|Error {
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_USER, userId]);
@@ -595,8 +595,8 @@ public client class ManagementClient {
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to 
     #                         the request
     # + return - If successful, returns a `stream<Data, error>`. Else returns `Error`.
-    @display {label: "Get users"} 
-    remote isolated function listUsers(@display {label: "Database Name"} string databaseId, 
+    @display {label: "Get Users"} 
+    remote isolated function listUsers(@display {label: "Database ID"} string databaseId, 
                                        @display {label: "Optional Header Parameters"} ResourceReadOptions? 
                                        resourceReadOptions = ()) returns @tainted @display {label: "Stream of Users"} 
                                        stream<Data, error>|Error { 
@@ -618,9 +618,9 @@ public client class ManagementClient {
     # + resourceDeleteOptions - The `ResourceDeleteOptions` which can be used to add additional 
     #                           capabilities to the request
     # + return - If successful, returns `DeleteResponse`. Else returns `Error`.
-    @display {label: "Delete user"} 
-    remote isolated function deleteUser(@display {label: "Database Name"} string databaseId, 
-                                        @display {label: "User Id"} string userId, 
+    @display {label: "Delete User"} 
+    remote isolated function deleteUser(@display {label: "Database ID"} string databaseId, 
+                                        @display {label: "User ID"} string userId, 
                                         @display {label: "Optional Header Parameters"} ResourceDeleteOptions? 
                                         resourceDeleteOptions = ()) returns @tainted DeleteResponse|Error {
         http:Request request = new;
@@ -642,10 +642,10 @@ public client class ManagementClient {
     # + resourcePath - The resource this permission is allowing the user to access
     # + validityPeriodInSeconds - Optional. Validity period of the permission in seconds.
     # + return - If successful, returns a `Permission`. Else returns `Error`.
-    @display {label: "Create permission"} 
-    remote isolated function createPermission(@display {label: "Database Name"} string databaseId, 
-                                              @display {label: "User Id"} string userId, 
-                                              @display {label: "Permission Id"} string permissionId, 
+    @display {label: "Create Permission"} 
+    remote isolated function createPermission(@display {label: "Database ID"} string databaseId, 
+                                              @display {label: "User ID"} string userId, 
+                                              @display {label: "Permission ID"} string permissionId, 
                                               @display {label: "Permission Mode"} PermisssionMode permissionMode, 
                                               @display {label: "Resource Path"} string resourcePath, 
                                               @display {label: "Validity Period in Seconds (optional)"} int? 
@@ -679,10 +679,10 @@ public client class ManagementClient {
     # + resourcePath - The resource this permission is allowing the user to access
     # + validityPeriodInSeconds - Optional. Validity period of the permission in seconds.
     # + return - If successful, returns a `Permission`. Else returns `Error`.
-    @display {label: "Replace permission"} 
-    remote isolated function replacePermission(@display {label: "Database Name"} string databaseId, 
-                                               @display {label: "User Id"} string userId, 
-                                               @display {label: "Permission Id"} string permissionId, 
+    @display {label: "Replace Permission"} 
+    remote isolated function replacePermission(@display {label: "Database ID"} string databaseId, 
+                                               @display {label: "User ID"} string userId, 
+                                               @display {label: "Permission ID"} string permissionId, 
                                                @display {label: "Permission Mode"} PermisssionMode permissionMode, 
                                                @display {label: "Resource Path"} string resourcePath, 
                                                @display {label: "Validity Period in Seconds (optional)"} int? 
@@ -714,10 +714,10 @@ public client class ManagementClient {
     # + permissionId - ID of the permission
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to the request
     # + return - If successful, returns a `Permission`. Else returns `Error`.
-    @display {label: "Get permission"} 
-    remote isolated function getPermission(@display {label: "Database Name"} string databaseId, 
-                                           @display {label: "User Id"} string userId,
-                                           @display {label: "Permission Id"} string permissionId, 
+    @display {label: "Get Permission"} 
+    remote isolated function getPermission(@display {label: "Database ID"} string databaseId, 
+                                           @display {label: "User ID"} string userId,
+                                           @display {label: "Permission ID"} string permissionId, 
                                            @display {label: "Optional Header Parameters"} ResourceReadOptions? 
                                            resourceReadOptions = ()) returns @tainted Permission|Error { 
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_USER, userId, 
@@ -738,9 +738,9 @@ public client class ManagementClient {
     # + userId - ID of user to which, the permissions are granted
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to the request
     # + return - If successful, returns a `stream<Data, error>`. Else returns `Error`.
-    @display {label: "Get permissions"} 
-    remote isolated function listPermissions(@display {label: "Database Name"} string databaseId, 
-                                             @display {label: "User Id"} string userId, 
+    @display {label: "Get Permissions"} 
+    remote isolated function listPermissions(@display {label: "Database ID"} string databaseId, 
+                                             @display {label: "User ID"} string userId, 
                                              @display {label: "Optional Header Parameters"} ResourceReadOptions? 
                                              resourceReadOptions = ()) returns 
                                              @tainted @display {label: "Stream of Permissions"} 
@@ -765,10 +765,10 @@ public client class ManagementClient {
     # + resourceDeleteOptions - The `ResourceDeleteOptions` which can be used to add additional capabilities to the 
     #                           request
     # + return - If successful, returns `DeleteResponse`. Else returns `Error`.
-    @display {label: "Delete permission"} 
-    remote isolated function deletePermission(@display {label: "Database Name"} string databaseId, 
-                                              @display {label: "User Id"} string userId, 
-                                              @display {label: "Permission Id"} string permissionId, 
+    @display {label: "Delete Permission"} 
+    remote isolated function deletePermission(@display {label: "Database ID"} string databaseId, 
+                                              @display {label: "User ID"} string userId, 
+                                              @display {label: "Permission ID"} string permissionId, 
                                               @display {label: " Optional Header Parameters"} ResourceDeleteOptions? 
                                               resourceDeleteOptions = ()) returns @tainted DeleteResponse|Error { 
         http:Request request = new;
@@ -787,8 +787,8 @@ public client class ManagementClient {
     # 
     # + offer - A record of type `Offer`
     # + return - If successful, returns a `Offer`. Else returns `Error`.
-    @display {label: "Replace offer"} 
-    remote isolated function replaceOffer(@display {label: "Offer Id"} Offer offer) returns @tainted Offer|Error {
+    @display {label: "Replace Offer"} 
+    remote isolated function replaceOffer(@display {label: "Offer ID"} Offer offer) returns @tainted Offer|Error {
         http:Request request = new;
         string requestPath = prepareUrl([RESOURCE_TYPE_OFFERS, offer.id]);
         check setMandatoryHeaders(request, self.host, self.primaryKeyOrResourceToken, http:HTTP_PUT, requestPath);
@@ -814,8 +814,8 @@ public client class ManagementClient {
     # + offerId - The ID of the offer
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to the request
     # + return - If successful, returns a `Offer`. Else returns `Error`.
-    @display {label: "Get offer"} 
-    remote isolated function getOffer(@display {label: "Offer Id"} string offerId, 
+    @display {label: "Get Offer"} 
+    remote isolated function getOffer(@display {label: "Offer ID"} string offerId, 
                                       @display {label: "Optional Header Parameters"} ResourceReadOptions? 
                                       resourceReadOptions = ()) returns @tainted Offer|Error {
         string requestPath = prepareUrl([RESOURCE_TYPE_OFFERS, offerId]);
@@ -834,7 +834,7 @@ public client class ManagementClient {
     # 
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to the request
     # + return - If successful, returns a `stream<Data, error>` Else returns `Error`.
-    @display {label: "Get offers"} 
+    @display {label: "Get Offers"} 
     remote isolated function listOffers(@display {label: " Optional Header Parameters"} ResourceReadOptions? 
                                         resourceReadOptions = ()) returns @tainted @display {label: "Stream of Offers"} 
                                         stream<Data, error>|Error { 
@@ -855,7 +855,7 @@ public client class ManagementClient {
     # + resourceQueryOptions - The `ResourceQueryOptions` which can be used to add additional capabilities to the 
     #                          request
     # + return - If successful, returns a `stream<QueryResult, error>`. Else returns `Error`.
-    @display {label: "Query offers"} 
+    @display {label: "Query Offers"} 
     remote isolated function queryOffer(@display {label: "SQL Query"} string sqlQuery, 
                                         @display {label: "Optional Header Parameters"} ResourceQueryOptions? 
                                         resourceQueryOptions = ()) returns 

--- a/management_endpoint.bal
+++ b/management_endpoint.bal
@@ -102,18 +102,19 @@ public client class ManagementClient {
 
     # List information of all databases.
     # 
-    # + return - If successful, returns `stream<Data, error>`. else returns `Error`.
+    # + return - If successful, returns `stream<Database, error>`. else returns `Error`.
     @display {label: "Get Databases"}  
     remote isolated function listDatabases() returns 
-                                          @tainted @display {label: "Stream of Databases"} stream<Data, error>|Error {
+                                          @tainted @display {label: "Stream of Databases"} 
+                                          stream<Database, error>|Error {
         http:Request request = new;
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES]);
 
         map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET, 
             requestPath);
 
-        RecordStream objectInstance = check new (self.httpClient, requestPath, headerMap);
-        stream<Data, error> finalStream = new (objectInstance);
+        DatabaseStream objectInstance = check new (self.httpClient, requestPath, headerMap);
+        stream<Database, error> finalStream = new (objectInstance);
         return finalStream;
     }
 
@@ -230,19 +231,19 @@ public client class ManagementClient {
     # List information of all containers.
     # 
     # + databaseId - ID of the database to which the containers belongs to
-    # + return - If successful, returns `stream<Data, error>`. Else returns `Error`.
+    # + return - If successful, returns `stream<Container, error>`. Else returns `Error`.
     @display {label: "Get Containers"} 
     remote isolated function listContainers(@display {label: "Database ID"} string databaseId) 
                                             returns @tainted @display {label: "Stream of Containers"} 
-                                            stream<Data, error>|Error {
+                                            stream<Container, error>|Error {
         http:Request request = new;
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS]);
 
         map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET, 
             requestPath);
 
-        RecordStream objectInstance = check new (self.httpClient, requestPath, headerMap);
-        stream<Data, error> finalStream = new (objectInstance);
+        ContainerStream objectInstance = check new (self.httpClient, requestPath, headerMap);
+        stream<Container, error> finalStream = new (objectInstance);
         return finalStream;
     }
 
@@ -273,20 +274,20 @@ public client class ManagementClient {
     # 
     # + databaseId - ID of the database to which the container belongs to
     # + containerId - ID of the container where the partition key ranges are related to
-    # + return - If successful, returns `stream<Data, error>`. Else returns `Error`.
+    # + return - If successful, returns `stream<PartitionKeyRange, error>`. Else returns `Error`.
     @display {label: "Get Partition Key Ranges"} 
     remote isolated function listPartitionKeyRanges(@display {label: "Database ID"} string databaseId, 
                                                     @display {label: "Container ID"} string containerId) returns 
                                                     @tainted @display {label: "Stream of Partition Key Ranges"} 
-                                                    stream<Data, error>|Error {
+                                                    stream<PartitionKeyRange, error>|Error {
         http:Request request = new;
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId, 
             RESOURCE_TYPE_PK_RANGES]);
         map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET, 
             requestPath);
 
-        RecordStream objectInstance = check new (self.httpClient, requestPath, headerMap);
-        stream<Data, error> finalStream = new (objectInstance);
+        PartitionKeyRangeStream objectInstance = check new (self.httpClient, requestPath, headerMap);
+        stream<PartitionKeyRange, error> finalStream = new (objectInstance);
         return finalStream;
     }
 
@@ -358,14 +359,14 @@ public client class ManagementClient {
     # + databaseId - ID of the database to which the container belongs to
     # + containerId - ID of the container which contains the user defined functions
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to the request
-    # + return - If successful, returns a `stream<Data, error>`. Else returns `Error`. 
+    # + return - If successful, returns a `stream<UserDefinedFunction, error>`. Else returns `Error`. 
     @display {label: "Get User Defined Functions"} 
     remote isolated function listUserDefinedFunctions(@display {label: "Database ID"} string databaseId, 
                                                       @display {label: "Container ID"} string containerId, 
                                                       @display {label: "Optional Header Parameters"} ResourceReadOptions? 
                                                       resourceReadOptions = ()) returns 
                                                       @tainted @display {label: "Stream of User Defined Fucntions"} 
-                                                      stream<Data, error>|Error { 
+                                                      stream<UserDefinedFunction, error>|Error { 
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId, 
             RESOURCE_TYPE_UDF]);
 
@@ -373,8 +374,8 @@ public client class ManagementClient {
             requestPath);
         headerMap = setOptionalGetHeaders(headerMap, resourceReadOptions);
 
-        RecordStream objectInstance = check new (self.httpClient, requestPath, headerMap);
-        stream<Data, error> finalStream = new (objectInstance);
+        UserDefiinedFunctionStream objectInstance = check new (self.httpClient, requestPath, headerMap);
+        stream<UserDefinedFunction, error> finalStream = new (objectInstance);
         return finalStream;
     }
 
@@ -482,13 +483,13 @@ public client class ManagementClient {
     # + databaseId - ID of the database to which the container belongs to
     # + containerId - ID of the container which contains the triggers
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to therequest
-    # + return - If successful, returns a `stream<Data, error>`. Else returns `Error`. 
+    # + return - If successful, returns a `stream<Trigger, error>`. Else returns `Error`. 
     @display {label: "Get Triggers"} 
     remote isolated function listTriggers(@display {label: "Database ID"} string databaseId, 
                                           @display {label: "Container ID"} string containerId, 
                                           @display {label: "Optional Header Parameters"} ResourceReadOptions?
                                           resourceReadOptions = ()) returns 
-                                          @tainted @display {label: "Stream of Triggers"} stream<Data, error>|Error { 
+                                          @tainted @display {label: "Stream of Triggers"} stream<Trigger, error>|Error { 
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId, 
             RESOURCE_TYPE_TRIGGER]);
 
@@ -496,8 +497,8 @@ public client class ManagementClient {
             requestPath);
         headerMap = setOptionalGetHeaders(headerMap, resourceReadOptions);
 
-        RecordStream objectInstance = check new (self.httpClient, requestPath, headerMap);
-        stream<Data, error> finalStream = new (objectInstance);
+        TriggerStream objectInstance = check new (self.httpClient, requestPath, headerMap);
+        stream<Trigger, error> finalStream = new (objectInstance);
         return finalStream;
     }
 
@@ -594,20 +595,20 @@ public client class ManagementClient {
     # + databaseId - ID of the database to which, the user belongs to
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to 
     #                         the request
-    # + return - If successful, returns a `stream<Data, error>`. Else returns `Error`.
+    # + return - If successful, returns a `stream<User, error>`. Else returns `Error`.
     @display {label: "Get Users"} 
     remote isolated function listUsers(@display {label: "Database ID"} string databaseId, 
                                        @display {label: "Optional Header Parameters"} ResourceReadOptions? 
                                        resourceReadOptions = ()) returns @tainted @display {label: "Stream of Users"} 
-                                       stream<Data, error>|Error { 
+                                       stream<User, error>|Error { 
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_USER]);
 
         map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET, 
             requestPath);
         headerMap = setOptionalGetHeaders(headerMap, resourceReadOptions);
 
-        RecordStream objectInstance = check new (self.httpClient, requestPath, headerMap);
-        stream<Data, error> finalStream = new (objectInstance);
+        UserStream objectInstance = check new (self.httpClient, requestPath, headerMap);
+        stream<User, error> finalStream = new (objectInstance);
         return finalStream;
     }
 
@@ -737,14 +738,14 @@ public client class ManagementClient {
     # + databaseId - ID of the database where the user is created
     # + userId - ID of user to which, the permissions are granted
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to the request
-    # + return - If successful, returns a `stream<Data, error>`. Else returns `Error`.
+    # + return - If successful, returns a `stream<Permission, error>`. Else returns `Error`.
     @display {label: "Get Permissions"} 
     remote isolated function listPermissions(@display {label: "Database ID"} string databaseId, 
                                              @display {label: "User ID"} string userId, 
                                              @display {label: "Optional Header Parameters"} ResourceReadOptions? 
                                              resourceReadOptions = ()) returns 
                                              @tainted @display {label: "Stream of Permissions"} 
-                                             stream<Data, error>|Error { 
+                                             stream<Permission, error>|Error { 
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_USER, userId, 
             RESOURCE_TYPE_PERMISSION]);
 
@@ -752,8 +753,8 @@ public client class ManagementClient {
             requestPath);
         headerMap = setOptionalGetHeaders(headerMap, resourceReadOptions);
         
-        RecordStream objectInstance = check new (self.httpClient, requestPath, headerMap);
-        stream<Data, error> finalStream = new (objectInstance);
+        PermissionStream objectInstance = check new (self.httpClient, requestPath, headerMap);
+        stream<Permission, error> finalStream = new (objectInstance);
         return finalStream;
     }
 
@@ -833,19 +834,19 @@ public client class ManagementClient {
     # performance levels and pre-defined performance levels. 
     # 
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to the request
-    # + return - If successful, returns a `stream<Data, error>` Else returns `Error`.
+    # + return - If successful, returns a `stream<Offer, error>` Else returns `Error`.
     @display {label: "Get Offers"} 
     remote isolated function listOffers(@display {label: " Optional Header Parameters"} ResourceReadOptions? 
                                         resourceReadOptions = ()) returns @tainted @display {label: "Stream of Offers"} 
-                                        stream<Data, error>|Error { 
+                                        stream<Offer, error>|Error { 
         string requestPath = prepareUrl([RESOURCE_TYPE_OFFERS]);
 
         map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET, 
             requestPath);
         headerMap = setOptionalGetHeaders(headerMap, resourceReadOptions);
 
-        RecordStream objectInstance = check new (self.httpClient, requestPath, headerMap);
-        stream<Data, error> finalStream = new (objectInstance);
+        OfferStream objectInstance = check new (self.httpClient, requestPath, headerMap);
+        stream<Offer, error> finalStream = new (objectInstance);
         return finalStream;
     }
 
@@ -854,13 +855,13 @@ public client class ManagementClient {
     # + sqlQuery - A string value containing SQL query
     # + resourceQueryOptions - The `ResourceQueryOptions` which can be used to add additional capabilities to the 
     #                          request
-    # + return - If successful, returns a `stream<QueryResult, error>`. Else returns `Error`.
+    # + return - If successful, returns a `stream<Offer, error>`. Else returns `Error`.
     @display {label: "Query Offers"} 
     remote isolated function queryOffer(@display {label: "SQL Query"} string sqlQuery, 
                                         @display {label: "Optional Header Parameters"} ResourceQueryOptions? 
                                         resourceQueryOptions = ()) returns 
                                         @tainted @display {label: "Stream of Query Results"} 
-                                        stream<QueryResult, error>|Error { 
+                                        stream<Offer, error>|Error { 
         http:Request request = new;
         string requestPath = prepareUrl([RESOURCE_TYPE_OFFERS]);
         check setMandatoryHeaders(request, self.host, self.primaryKeyOrResourceToken, http:HTTP_POST, requestPath);
@@ -869,8 +870,8 @@ public client class ManagementClient {
         request.setJsonPayload({query: sqlQuery});
         check setHeadersForQuery(request);
 
-        QueryResultStream objectInstance = check new (self.httpClient, requestPath, request);
-        stream<QueryResult, error> finalStream = new (objectInstance);
+        OfferQueryResultStream objectInstance = check new (self.httpClient, requestPath, request);
+        stream<Offer, error> finalStream = new (objectInstance);
         return finalStream;
     }
 }

--- a/samples/admin-operations/container/container_operations.bal
+++ b/samples/admin-operations/container/container_operations.bal
@@ -151,10 +151,10 @@ public function main() {
     }
 
     log:printInfo("Getting list of containers");
-    stream<cosmosdb:Data,error>|error containerList = managementClient->listContainers(databaseId);
+    stream<cosmosdb:Container,error>|error containerList = managementClient->listContainers(databaseId);
 
-    if (containerList is stream<cosmosdb:Data,error>) {
-        error? e = containerList.forEach(function (cosmosdb:Data container) {
+    if (containerList is stream<cosmosdb:Container,error>) {
+        error? e = containerList.forEach(function (cosmosdb:Container container) {
             log:printInfo(container.toString());
         });
     } else {

--- a/samples/admin-operations/container/list_containers.bal
+++ b/samples/admin-operations/container/list_containers.bal
@@ -29,10 +29,10 @@ public function main() {
     string databaseId = "my_database";
 
     log:printInfo("Getting list of containers");   
-    stream<cosmosdb:Data, error>|error result = managementClient->listContainers(databaseId);
+    stream<cosmosdb:Container, error>|error result = managementClient->listContainers(databaseId);
 
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data container) {
+    if (result is stream<cosmosdb:Container, error>) {
+        error? e = result.forEach(function (cosmosdb:Container container) {
             log:printInfo(container.toString());
         });
         log:printInfo("Success!");

--- a/samples/admin-operations/database/database_operations.bal
+++ b/samples/admin-operations/database/database_operations.bal
@@ -102,10 +102,10 @@ public function main() {
     }
 
     log:printInfo("Getting list of databases");
-    stream<cosmosdb:Data,error>|error databaseList = managementClient->listDatabases();
+    stream<cosmosdb:Database,error>|error databaseList = managementClient->listDatabases();
 
-    if (databaseList is stream<cosmosdb:Data,error>) {
-        error? e = databaseList.forEach(function (cosmosdb:Data database) {
+    if (databaseList is stream<cosmosdb:Database,error>) {
+        error? e = databaseList.forEach(function (cosmosdb:Database database) {
             log:printInfo(database.toString());
         });
     } else {

--- a/samples/admin-operations/database/list_databases.bal
+++ b/samples/admin-operations/database/list_databases.bal
@@ -27,10 +27,10 @@ cosmosdb:ManagementClient managementClient = check new (config);
 
 public function main() {
     log:printInfo("Getting list of databases");
-    stream<cosmosdb:Data, error>|error result = managementClient->listDatabases();
+    stream<cosmosdb:Database, error>|error result = managementClient->listDatabases();
 
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data database) {
+    if (result is stream<cosmosdb:Database, error>) {
+        error? e = result.forEach(function (cosmosdb:Database database) {
             log:printInfo(database.toString());
         });
         log:printInfo("Success!");

--- a/samples/admin-operations/offers/offer_operations.bal
+++ b/samples/admin-operations/offers/offer_operations.bal
@@ -39,11 +39,11 @@ public function main() {
     cosmosdb:Container container = checkpanic managementClient->getContainer(databaseId, containerId);
 
     log:printInfo("List the offers in the current cosmos db account");   
-    stream<cosmosdb:Data, error>|error offerList = checkpanic managementClient->listOffers();
+    stream<cosmosdb:Offer, error>|error offerList = checkpanic managementClient->listOffers();
 
-    if (offerList is stream<cosmosdb:Data, error>) {
-        record {|cosmosdb:Data value;|}|error? offer = offerList.next();
-        if (offer is record {|cosmosdb:Data value;|}) {
+    if (offerList is stream<cosmosdb:Offer, error>) {
+        record {|cosmosdb:Offer value;|}|error? offer = offerList.next();
+        if (offer is record {|cosmosdb:Offer value;|}) {
             offerId = <@untainted>offer.value.id;
             resourceId = offer?.value?.resourceId;
         }

--- a/samples/admin-operations/triggers/list_trigger.bal
+++ b/samples/admin-operations/triggers/list_trigger.bal
@@ -30,10 +30,10 @@ public function main() {
     string containerId = "my_container";
 
     log:printInfo("List available triggers");
-    stream<cosmosdb:Data, error>|error result = managementClient->listTriggers(databaseId, containerId);
+    stream<cosmosdb:Trigger, error>|error result = managementClient->listTriggers(databaseId, containerId);
 
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data trigger) {
+    if (result is stream<cosmosdb:Trigger, error>) {
+        error? e = result.forEach(function (cosmosdb:Trigger trigger) {
             log:printInfo(trigger.toString());
         });
         log:printInfo("Success!");

--- a/samples/admin-operations/triggers/trigger_operations.bal
+++ b/samples/admin-operations/triggers/trigger_operations.bal
@@ -114,10 +114,10 @@ public function main() {
     }
 
     log:printInfo("List available triggers");
-    stream<cosmosdb:Data, error>|error triggerList = managementClient->listTriggers(databaseId, containerId);
+    stream<cosmosdb:Trigger, error>|error triggerList = managementClient->listTriggers(databaseId, containerId);
 
-    if (triggerList is stream<cosmosdb:Data, error>) {
-        error? e = triggerList.forEach(function (cosmosdb:Data trigger) {
+    if (triggerList is stream<cosmosdb:Trigger, error>) {
+        error? e = triggerList.forEach(function (cosmosdb:Trigger trigger) {
             log:printInfo(trigger.toString());
         });
         log:printInfo("Success!");

--- a/samples/admin-operations/user-defined-functions/list_udf.bal
+++ b/samples/admin-operations/user-defined-functions/list_udf.bal
@@ -30,10 +30,10 @@ public function main() {
     string containerId = "my_container";
 
     log:printInfo("List  user defined functions");
-    stream<cosmosdb:Data, error>|error result = managementClient->listUserDefinedFunctions(databaseId, containerId);
+    stream<cosmosdb:UserDefinedFunction, error>|error result = managementClient->listUserDefinedFunctions(databaseId, containerId);
 
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data udf) {
+    if (result is stream<cosmosdb:UserDefinedFunction, error>) {
+        error? e = result.forEach(function (cosmosdb:UserDefinedFunction udf) {
             log:printInfo(udf.toString());
         });
         log:printInfo("Success!");

--- a/samples/admin-operations/user-defined-functions/user_defined_functions.bal
+++ b/samples/admin-operations/user-defined-functions/user_defined_functions.bal
@@ -79,9 +79,9 @@ public function main() {
     }
 
     log:printInfo("List  user defined functions(udf)s");
-    stream<cosmosdb:Data, error>|error udfList = managementClient->listUserDefinedFunctions(databaseId, containerId);
-    if (udfList is stream<cosmosdb:Data, error>) {
-        error? e = udfList.forEach(function (cosmosdb:Data udf) {
+    stream<cosmosdb:UserDefinedFunction, error>|error udfList = managementClient->listUserDefinedFunctions(databaseId, containerId);
+    if (udfList is stream<cosmosdb:UserDefinedFunction, error>) {
+        error? e = udfList.forEach(function (cosmosdb:UserDefinedFunction udf) {
             log:printInfo(udf.toString());
         });
         log:printInfo("Success!");

--- a/samples/admin-operations/users-permissions/permission/list_permissions.bal
+++ b/samples/admin-operations/users-permissions/permission/list_permissions.bal
@@ -30,10 +30,10 @@ public function main() {
     string userId = "my_user";
 
     log:printInfo("List permissions");
-    stream<cosmosdb:Data, error>|error result = managementClient->listPermissions(databaseId, userId);
+    stream<cosmosdb:Permission, error>|error result = managementClient->listPermissions(databaseId, userId);
 
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data storedPrcedure) {
+    if (result is stream<cosmosdb:Permission, error>) {
+        error? e = result.forEach(function (cosmosdb:Permission storedPrcedure) {
             log:printInfo(storedPrcedure.toString());
         });
         log:printInfo("Success!");

--- a/samples/admin-operations/users-permissions/user/list_users.bal
+++ b/samples/admin-operations/users-permissions/user/list_users.bal
@@ -29,9 +29,9 @@ public function main() {
     string databaseId = "my_database";
 
     log:printInfo("List users");
-    stream<cosmosdb:Data, error>|error result = managementClient->listUsers(databaseId);
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data storedPrcedure) {
+    stream<cosmosdb:User, error>|error result = managementClient->listUsers(databaseId);
+    if (result is stream<cosmosdb:User, error>) {
+        error? e = result.forEach(function (cosmosdb:User storedPrcedure) {
             log:printInfo(storedPrcedure.toString());
         });
         log:printInfo("Success!");

--- a/samples/admin-operations/users-permissions/users_access_control.bal
+++ b/samples/admin-operations/users-permissions/users_access_control.bal
@@ -69,9 +69,9 @@ public function main() {
     }
 
     log:printInfo("List users");
-    stream<cosmosdb:Data, error>|error userList = managementClient->listUsers(databaseId);
-    if (userList is stream<cosmosdb:Data, error>) {
-        error? e = userList.forEach(function (cosmosdb:Data storedPrcedure) {
+    stream<cosmosdb:User, error>|error userList = managementClient->listUsers(databaseId);
+    if (userList is stream<cosmosdb:User, error>) {
+        error? e = userList.forEach(function (cosmosdb:User storedPrcedure) {
             log:printInfo(storedPrcedure.toString());
         });
         log:printInfo("Success!");
@@ -130,9 +130,9 @@ public function main() {
     }
 
     log:printInfo("List permissions");
-    stream<cosmosdb:Data, error>|error permissionList = managementClient->listPermissions(databaseId, userId);
-    if (permissionList is stream<cosmosdb:Data, error>) {
-        error? e = permissionList.forEach(function (cosmosdb:Data storedPrcedure) {
+    stream<cosmosdb:Permission, error>|error permissionList = managementClient->listPermissions(databaseId, userId);
+    if (permissionList is stream<cosmosdb:Permission, error>) {
+        error? e = permissionList.forEach(function (cosmosdb:Permission storedPrcedure) {
             log:printInfo(storedPrcedure.toString());
         });
         log:printInfo("Success!");

--- a/samples/data-operations/documents/document_operations.bal
+++ b/samples/data-operations/documents/document_operations.bal
@@ -173,10 +173,10 @@ public function main() {
     }
 
     log:printInfo("Getting list of documents");
-    stream<cosmosdb:Data, error>|error documentList = azureCosmosClient->getDocumentList(databaseId, containerId);
+    stream<cosmosdb:Document, error>|error documentList = azureCosmosClient->getDocumentList(databaseId, containerId);
 
-    if (documentList is stream<cosmosdb:Data, error>) {
-        error? e = documentList.forEach(function (cosmosdb:Data document) {
+    if (documentList is stream<cosmosdb:Document, error>) {
+        error? e = documentList.forEach(function (cosmosdb:Document document) {
             log:printInfo(document.toString());
         });
         log:printInfo("Success!");

--- a/samples/data-operations/documents/list_documents.bal
+++ b/samples/data-operations/documents/list_documents.bal
@@ -30,10 +30,10 @@ public function main() {
     string containerId = "my_container";
 
     log:printInfo("Getting list of documents");
-    stream<cosmosdb:Data, error>|error result = azureCosmosClient->getDocumentList(databaseId, containerId);
+    stream<cosmosdb:Document, error>|error result = azureCosmosClient->getDocumentList(databaseId, containerId);
 
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data document) {
+    if (result is stream<cosmosdb:Document, error>) {
+        error? e = result.forEach(function (cosmosdb:Document document) {
             log:printInfo(document.toString());
         });
         log:printInfo("Success!");

--- a/samples/data-operations/documents/query_document.bal
+++ b/samples/data-operations/documents/query_document.bal
@@ -33,11 +33,11 @@ public function main() {
     string selectAllQuery = string `SELECT * FROM ${containerId.toString()} f WHERE f.gender = ${0}`;
 
     cosmosdb:ResourceQueryOptions options = {partitionKey : 0, enableCrossPartition: false};
-    stream<cosmosdb:QueryResult, error>|error result = azureCosmosClient->queryDocuments(databaseId, containerId, 
+    stream<cosmosdb:Document, error>|error result = azureCosmosClient->queryDocuments(databaseId, containerId, 
         selectAllQuery, options);
 
-    if (result is stream<cosmosdb:QueryResult, error>) {
-        error? e = result.forEach(function (cosmosdb:QueryResult queryResult) {
+    if (result is stream<cosmosdb:Document, error>) {
+        error? e = result.forEach(function (cosmosdb:Document queryResult) {
             log:printInfo(queryResult.toString());
         });
         log:printInfo("Success!");

--- a/samples/data-operations/stored-procedure/list_stored_procedure.bal
+++ b/samples/data-operations/stored-procedure/list_stored_procedure.bal
@@ -30,9 +30,9 @@ public function main() {
     string containerId = "my_container";
 
     log:printInfo("List stored procedure");
-    stream<cosmosdb:Data, error>|error result = azureCosmosClient->listStoredProcedures(databaseId, containerId);
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data storedPrcedure) {
+    stream<cosmosdb:StoredProcedure, error>|error result = azureCosmosClient->listStoredProcedures(databaseId, containerId);
+    if (result is stream<cosmosdb:StoredProcedure, error>) {
+        error? e = result.forEach(function (cosmosdb:StoredProcedure storedPrcedure) {
             log:printInfo(storedPrcedure.toString());
         });
         log:printInfo("Success!");

--- a/samples/data-operations/stored-procedure/stored_procedure_operations.bal
+++ b/samples/data-operations/stored-procedure/stored_procedure_operations.bal
@@ -66,9 +66,9 @@ public function main() {
     }
 
     log:printInfo("List stored procedures");
-    stream<cosmosdb:Data, error>|error spList = azureCosmosClient->listStoredProcedures(databaseId, containerId);
-    if (spList is stream<cosmosdb:Data, error>) {
-        error? e = spList.forEach(function (cosmosdb:Data storedPrcedure) {
+    stream<cosmosdb:StoredProcedure, error>|error spList = azureCosmosClient->listStoredProcedures(databaseId, containerId);
+    if (spList is stream<cosmosdb:StoredProcedure, error>) {
+        error? e = spList.forEach(function (cosmosdb:StoredProcedure storedPrcedure) {
             log:printInfo(storedPrcedure.toString());
         });
         log:printInfo("Success!");

--- a/tests/test.bal
+++ b/tests/test.bal
@@ -166,8 +166,8 @@ function testListAllDatabases() {
     log:printInfo("ACTION : listAllDatabases()");
 
     var result = azureCosmosManagementClient->listDatabases();
-    if (result is stream<Data, error>) {
-        error? e = result.forEach(isolated function (Data queryResult) {
+    if (result is stream<Database, error>) {
+        error? e = result.forEach(isolated function (Database queryResult) {
             log:printInfo(queryResult.toString());
         });     
     } else {
@@ -286,8 +286,8 @@ function testGetAllContainers() {
     log:printInfo("ACTION : getAllContainers()");
 
     var result = azureCosmosManagementClient->listContainers(databaseId);
-    if (result is stream<Data, error>) {
-        error? e = result.forEach(isolated function (Data queryResult) {
+    if (result is stream<Container, error>) {
+        error? e = result.forEach(isolated function (Container queryResult) {
             log:printInfo(queryResult.toString());
         }); 
     } else {
@@ -435,8 +435,8 @@ function testGetDocumentList() {
     log:printInfo("ACTION : getDocumentList()");
 
     var result = azureCosmosClient->getDocumentList(databaseId, containerId);
-    if (result is stream<Data, error>) {
-        error? e = result.forEach(isolated function (Data queryResult) {
+    if (result is stream<Document, error>) {
+        error? e = result.forEach(isolated function (Document queryResult) {
             log:printInfo(queryResult.toString());
         }); 
     } else {
@@ -458,8 +458,8 @@ function testGetDocumentListWithRequestOptions() {
         partitionKeyRangeId: "0"
     };
     var result = azureCosmosClient->getDocumentList(databaseId, containerId, options);
-    if (result is stream<Data, error>) {
-        error? e = result.forEach(isolated function (Data queryResult) {
+    if (result is stream<Document, error>) {
+        error? e = result.forEach(isolated function (Document queryResult) {
             log:printInfo(queryResult.toString());
         }); 
     } else {
@@ -516,8 +516,8 @@ function testQueryDocuments() {
     string query = string `SELECT * FROM ${container.id.toString()} f WHERE f.Address.City = 'NY'`;
 
     var result = azureCosmosClient->queryDocuments(databaseId, containerId, query, options);
-    if (result is stream<QueryResult, error>) {
-        error? e = result.forEach(isolated function (QueryResult queryResult) {
+    if (result is stream<Document, error>) {
+        error? e = result.forEach(isolated function (Document queryResult) {
             log:printInfo(queryResult.toString());
         }); 
     } else {
@@ -539,8 +539,8 @@ function testQueryDocumentsWithRequestOptions() {
     };
 
     var result = azureCosmosClient->queryDocuments(databaseId, containerId, query, options);
-    if (result is stream<QueryResult, error>) {
-        error? e = result.forEach(isolated function (QueryResult queryResult) {
+    if (result is stream<Document, error>) {
+        error? e = result.forEach(isolated function (Document queryResult) {
             log:printInfo(queryResult.toString());
         }); 
     } else {
@@ -638,8 +638,8 @@ function testGetAllStoredProcedures() {
     log:printInfo("ACTION : getAllStoredProcedures()");
 
     var result = azureCosmosClient->listStoredProcedures(databaseId, containerId);
-    if (result is stream<Data, error>) {
-        error? e = result.forEach(isolated function (Data queryResult) {
+    if (result is stream<StoredProcedure, error>) {
+        error? e = result.forEach(isolated function (StoredProcedure queryResult) {
             log:printInfo(queryResult.toString());
         }); 
     } else {
@@ -726,8 +726,8 @@ function testListAllUDF() {
     log:printInfo("ACTION : listAllUDF()");
 
     var result = azureCosmosManagementClient->listUserDefinedFunctions(databaseId, containerId);
-    if (result is stream<Data, error>) {
-        error? e = result.forEach(isolated function (Data queryResult) {
+    if (result is stream<UserDefinedFunction, error>) {
+        error? e = result.forEach(isolated function (UserDefinedFunction queryResult) {
             log:printInfo(queryResult.toString());
         });    
     } else {
@@ -851,8 +851,8 @@ function testListTriggers() {
     log:printInfo("ACTION : listTriggers()");
 
     var result = azureCosmosManagementClient->listTriggers(databaseId, containerId);
-    if (result is stream<Data, error>) {
-        error? e = result.forEach(isolated function (Data queryResult) {
+    if (result is stream<Trigger, error>) {
+        error? e = result.forEach(isolated function (Trigger queryResult) {
             log:printInfo(queryResult.toString());
         }); 
     } else {
@@ -939,8 +939,8 @@ function testListUsers() {
     log:printInfo("ACTION : listUsers()");
 
     var result = azureCosmosManagementClient->listUsers(databaseId);
-    if (result is stream<Data, error>) {
-        error? e = result.forEach(isolated function (Data queryResult) {
+    if (result is stream<User, error>) {
+        error? e = result.forEach(isolated function (User queryResult) {
             log:printInfo(queryResult.toString());
         }); 
     } else {
@@ -1046,8 +1046,8 @@ function testListPermissions() {
     log:printInfo("ACTION : listPermissions()");
 
     var result = azureCosmosManagementClient->listPermissions(databaseId, newUserId);
-    if (result is stream<Data, error>) {
-        error? e = result.forEach(isolated function (Data queryResult) {
+    if (result is stream<Permission, error>) {
+        error? e = result.forEach(isolated function (Permission queryResult) {
             log:printInfo(queryResult.toString());
         }); 
     } else {
@@ -1096,12 +1096,12 @@ function testListOffers() {
     log:printInfo("ACTION : listOffers()");
 
     var result = azureCosmosManagementClient->listOffers();
-    if (result is stream<Data, error>) {
-        record {|Data value;|}|error? offer = result.next();
-        if (offer is record {|Data value;|}) {
+    if (result is stream<Offer, error>) {
+        record {|Offer value;|}|error? offer = result.next();
+        if (offer is record {|Offer value;|}) {
             offerId = <@untainted>offer?.value?.id;
             runtime:sleep(1);
-            resourceId = offer?.value?.resourceId;
+            resourceId = <@untainted>offer?.value?.resourceId;
         } else {
             log:printInfo("Empty stream");
         }

--- a/types.bal
+++ b/types.bal
@@ -43,7 +43,7 @@ public type DeleteResponse record {|
 # + sessionToken - Session token of the request
 @display{label: "Response Metadata"}
 public type Commons record {|
-    @display{label: "Resource Id"}
+    @display{label: "Resource ID"}
     string resourceId?;
     @display{label: "Self URI"}
     string selfReference?;
@@ -85,7 +85,7 @@ public type Container record {|
 # + documentBody - The document reprsented as a map of json
 @display{label: "Document"}
 public type Document record {|
-    @display{label: "Document Id"}
+    @display{label: "Document ID"}
     string id;
     *Commons;
     @display{label: "Document Body"}
@@ -173,20 +173,20 @@ public type PartitionKey record {|
 # + storedProcedure - A JavaScript function, respresented as a string
 @display{label: "Stored Procedure"}
 public type StoredProcedure record {|
-    @display{label: "Stored Procedure Id"}
+    @display{label: "Stored Procedure ID"}
     string id;
     *Commons;
     @display{label: "Stored Procedure"}
     string storedProcedure;
 |};
 
-# Represent the record type with necessary parameters to represent a user defined function.
+# Represent the record type with necessary parameters to represent a User Defined Function.
 # 
-# + id - User generated unique ID for the user defined function
+# + id - User generated unique ID for the User Defined Function
 # + userDefinedFunction - A JavaScript function, respresented as a string
 @display{label: "User Defined Function"}
 public type UserDefinedFunction record {|
-    @display{label: "User Defined Function Id"}
+    @display{label: "User Defined Function ID"}
     string id;
     *Commons;
     @display{label: "User Defined Function"}
@@ -201,7 +201,7 @@ public type UserDefinedFunction record {|
 # + triggerType - When the trigger is fired, `Pre` or `Post`
 @display{label: "Trigger"}
 public type Trigger record {|
-    @display{label: "Trigger Id"}
+    @display{label: "Trigger ID"}
     string id;
     *Commons;
     @display{label: "Trigger"}
@@ -219,7 +219,7 @@ public type Trigger record {|
 # + maxExclusive - Maximum partition key hash value for the partition key range
 @display{label: "Partition Key Range"}
 public type PartitionKeyRange record {|
-    @display{label: "Partition Key Range Id"}
+    @display{label: "Partition Key Range ID"}
     string id;
     *Commons;
     @display{label: " Minimum Partition Key Hash"}
@@ -234,7 +234,7 @@ public type PartitionKeyRange record {|
 # + permissions - A system generated property that specifies the addressable path of the permissions resource
 @display{label: "User"}
 public type User record {|
-    @display{label: "User Id"}
+    @display{label: "User ID"}
     string id;
     *Commons;
     @display{label: "Permission Path"}
@@ -249,7 +249,7 @@ public type User record {|
 # + token - System generated `Resource-Token` for the particular resource and user
 @display{label: "Permission"}
 public type Permission record {|
-    @display{label: "Permission Id"}
+    @display{label: "Permission ID"}
     string id;
     *Commons;
     @display{label: "Access Mode"}
@@ -271,7 +271,7 @@ public type Permission record {|
 # + resourceSelfLink - The self-link(_self) of the collection
 @display{label: "Offer"}
 public type Offer record {|
-    @display{label: "Offer Id"}
+    @display{label: "Offer ID"}
     string id;
     *Commons;
     @display{label: "Offer Version"}
@@ -280,7 +280,7 @@ public type Offer record {|
     OfferType offerType;
     @display{label: "Offer Information"}
     map<json> content;
-    @display{label: "Resource Id"}
+    @display{label: "Resource ID"}
     string resourceResourceId;
     @display{label: "Self URI"}
     string resourceSelfLink;
@@ -324,7 +324,7 @@ public type DocumentListOptions record {|
     string sessionToken?;
     @display{label: "Change Feed Option"}
     ChangeFeedOption changeFeedOption?;
-    @display{label: "Partition Key Range Id"}
+    @display{label: "Partition Key Range ID"}
     string partitionKeyRangeId?;
 |};
 

--- a/types.bal
+++ b/types.bal
@@ -386,5 +386,3 @@ public type ResourceDeleteOptions record {|
 type Options DocumentCreateOptions|DocumentReplaceOptions|DocumentListOptions|ResourceReadOptions|
     ResourceQueryOptions|ResourceDeleteOptions;
 
-# A Union type containing `Document`, `Offer`
-public type QueryResult Document|Offer;

--- a/types.bal
+++ b/types.bal
@@ -386,10 +386,5 @@ public type ResourceDeleteOptions record {|
 type Options DocumentCreateOptions|DocumentReplaceOptions|DocumentListOptions|ResourceReadOptions|
     ResourceQueryOptions|ResourceDeleteOptions;
 
-# A Union type containing `Document`, `Database`, `Container`, `StoredProcedure`, `UserDefinedFunction`, `Trigger`, 
-# `User`, `Permission`, `Offer` and `PartitionKeyRange`
-public type Data Document|Database|Container|StoredProcedure|UserDefinedFunction|Trigger|User|Permission|Offer|
-    PartitionKeyRange;
-
 # A Union type containing `Document`, `Offer`
 public type QueryResult Document|Offer;


### PR DESCRIPTION
## Purpose
> $subject

## Goals
> The current implementation of Cosmos DB connector, stream return types provide a Union type called `Data` in each operation which must be then cast to the relevant type by the user. To fix this the return types of streams must contain individual types inside.

## Approach
> The current stream implementer class must be repeated for each type. This is because the Stream<Data> output cannot be cast to get the specific type inside the ballerina code. So they must be handled separately using separate classes

## Release note
> Change the stream types to return single record type inside it. To enhance user experience in using the connector

## Documentation
https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/README.md

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Samples related to list operations can be found here
https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/tree/main/cosmosdb/samples

## Test environment
> Ubuntu 20.04 LTS
> Java 11
> Ballerina SL Alpha 5
 