### PR TITLE
[SL Beta 1] Change the streams to return individual types 

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,9 @@ For listing the existing documents inside this Cosmos container you have to give
 parameters. Here, you will get a stream of `Document` records as the response. Using the ballerina Stream API you can 
 access the returned results.
 ```ballerina
-stream<cosmosdb:Data, error>|error result = azureCosmosClient->listTriggers("my_database", "my_container");
-if (result is stream<cosmosdb:Data, error>) {
-    error? e = result.forEach(function (cosmosdb:Data document) {
+stream<cosmosdb:Document, error>|error result = azureCosmosClient->listTriggers("my_database", "my_container");
+if (result is stream<cosmosdb:Document, error>) {
+    error? e = result.forEach(function (cosmosdb:Document document) {
         log:printInfo(document.toString());
     });
     log:printInfo("Success!");
@@ -209,11 +209,11 @@ https://docs.microsoft.com/en-us/rest/api/cosmos-db/querying-cosmosdb-resources-
 string selectAllQuery = string `SELECT * FROM ${containerId.toString()} f WHERE f.gender = ${0}`;
 cosmosdb:ResourceQueryOptions options = {partitionKey : 0, enableCrossPartition: false};
 
-stream<cosmosdb:QueryResult, error>|error result = azureCosmosClient->queryDocuments("my_database", "my_container", 
+stream<cosmosdb:Document, error>|error result = azureCosmosClient->queryDocuments("my_database", "my_container", 
     selectAllQuery, options);
 
-if (result is stream<cosmosdb:QueryResult, error>) {
-    error? e = result.forEach(function (cosmosdb:QueryResult queryResult) {
+if (result is stream<cosmosdb:Document, error>) {
+    error? e = result.forEach(function (cosmosdb:Document queryResult) {
         log:printInfo(queryResult.toString());
     });
     log:printInfo("Success!");
@@ -482,10 +482,10 @@ public function main() {
     string containerId = "my_container";
 
     log:printInfo("Getting list of documents");
-    stream<cosmosdb:Data, error>|error result = azureCosmosClient->getDocumentList(databaseId, containerId);
+    stream<cosmosdb:Document, error>|error result = azureCosmosClient->getDocumentList(databaseId, containerId);
 
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data document) {
+    if (result is stream<cosmosdb:Document, error>) {
+        error? e = result.forEach(function (cosmosdb:Document document) {
             log:printInfo(document.toString());
         });
         log:printInfo("Success!");
@@ -575,11 +575,11 @@ public function main() {
     string selectAllQuery = string `SELECT * FROM ${containerId.toString()} f WHERE f.gender = ${0}`;
 
     cosmosdb:ResourceQueryOptions options = {partitionKey : 0, enableCrossPartition: false};
-    stream<cosmosdb:QueryResult, error>|error result = azureCosmosClient->queryDocuments(databaseId, containerId, 
+    stream<cosmosdb:Document, error>|error result = azureCosmosClient->queryDocuments(databaseId, containerId, 
         selectAllQuery, options);
 
-    if (result is stream<cosmosdb:QueryResult, error>) {
-        error? e = result.forEach(function (cosmosdb:QueryResult queryResult) {
+    if (result is stream<cosmosdb:Document, error>) {
+        error? e = result.forEach(function (cosmosdb:Document queryResult) {
             log:printInfo(queryResult.toString());
         });
         log:printInfo("Success!");
@@ -719,10 +719,10 @@ public function main() {
     string containerId = "my_container";
 
     log:printInfo("List stored procedure");
-    stream<cosmosdb:Data, error>?|error result = azureCosmosClient->listStoredProcedures(databaseId, containerId);
-    if (result is stream<cosmosdb:Data, error>?) {
-        if (result is stream<cosmosdb:Data, error>) {
-            error? e = result.forEach(function (cosmosdb:Data storedPrcedure) {
+    stream<cosmosdb:StoredProcedure, error>?|error result = azureCosmosClient->listStoredProcedures(databaseId, containerId);
+    if (result is stream<cosmosdb:StoredProcedure, error>?) {
+        if (result is stream<cosmosdb:StoredProcedure, error>) {
+            error? e = result.forEach(function (cosmosdb:StoredProcedure storedPrcedure) {
                 log:printInfo(storedPrcedure.toString());
             });
             log:printInfo("Success!");
@@ -936,10 +936,10 @@ cosmosdb:ManagementClient managementClient = check new (config);
 
 public function main() {
     log:printInfo("Getting list of databases");
-    stream<cosmosdb:Data, error>|error result = managementClient->listDatabases();
+    stream<cosmosdb:Database, error>|error result = managementClient->listDatabases();
 
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data database) {
+    if (result is stream<cosmosdb:Database, error>) {
+        error? e = result.forEach(function (cosmosdb:Database database) {
             log:printInfo(database.toString());
         });
         log:printInfo("Success!");
@@ -1088,10 +1088,10 @@ public function main() {
     string databaseId = "my_database";
 
     log:printInfo("Getting list of containers");   
-    stream<cosmosdb:Data, error>|error result = managementClient->listContainers(databaseId);
+    stream<cosmosdb:Container, error>|error result = managementClient->listContainers(databaseId);
 
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data container) {
+    if (result is stream<cosmosdb:Container, error>) {
+        error? e = result.forEach(function (cosmosdb:Container container) {
             log:printInfo(container.toString());
         });
         log:printInfo("Success!");
@@ -1263,10 +1263,10 @@ public function main() {
     string containerId = "my_container";
 
     log:printInfo("List  user defined functions");
-    stream<cosmosdb:Data, error>|error result = managementClient->listUserDefinedFunctions(databaseId, containerId);
+    stream<cosmosdb:UserDefinedFunction, error>|error result = managementClient->listUserDefinedFunctions(databaseId, containerId);
 
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data udf) {
+    if (result is stream<cosmosdb:UserDefinedFunction, error>) {
+        error? e = result.forEach(function (cosmosdb:UserDefinedFunction udf) {
             log:printInfo(udf.toString());
         });
         log:printInfo("Success!");
@@ -1477,10 +1477,10 @@ public function main() {
     string containerId = "my_container";
 
     log:printInfo("List available triggers");
-    stream<cosmosdb:Data, error>|error result = managementClient->listTriggers(databaseId, containerId);
+    stream<cosmosdb:Trigger, error>|error result = managementClient->listTriggers(databaseId, containerId);
 
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data trigger) {
+    if (result is stream<cosmosdb:Trigger, error>) {
+        error? e = result.forEach(function (cosmosdb:Trigger trigger) {
             log:printInfo(trigger.toString());
         });
         log:printInfo("Success!");
@@ -1655,9 +1655,9 @@ public function main() {
     string databaseId = "my_database";
 
     log:printInfo("List users");
-    stream<cosmosdb:Data, error>|error result = managementClient->listUsers(databaseId);
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data storedPrcedure) {
+    stream<cosmosdb:Users, error>|error result = managementClient->listUsers(databaseId);
+    if (result is stream<cosmosdb:Users, error>) {
+        error? e = result.forEach(function (cosmosdb:Users storedPrcedure) {
             log:printInfo(storedPrcedure.toString());
         });
         log:printInfo("Success!");
@@ -1863,10 +1863,10 @@ public function main() {
     string userId = "my_user";
 
     log:printInfo("List permissions");
-    stream<cosmosdb:Data, error>|error result = managementClient->listPermissions(databaseId, userId);
+    stream<cosmosdb:Permission, error>|error result = managementClient->listPermissions(databaseId, userId);
 
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data storedPrcedure) {
+    if (result is stream<cosmosdb:Permission, error>) {
+        error? e = result.forEach(function (cosmosdb:Permission storedPrcedure) {
             log:printInfo(storedPrcedure.toString());
         });
         log:printInfo("Success!");

--- a/README.md
+++ b/README.md
@@ -100,8 +100,7 @@ https://docs.microsoft.com/en-us/azure/cosmos-db/how-to-manage-database-account/
 - Java 11 installed. <br/>
     Java Development Kit (JDK) with version 11 is required.
 
-- Ballerina SL Alpha 5 installed. <br/>
-    Ballerina Swan Lake Alpha 5 is required.
+- Ballerina SL Beta 1 installed. <br/>
 
 ## Add project configurations file
 
@@ -413,7 +412,7 @@ in `DocumentReplaceOptions` record type in the connector.
 - **indexingDirective** - This option is to specify whether the document is included in any predefined indexing policy 
 for the container. This is provided by giving **Include** or **Exclude**.
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/data-operations/documents/replace_document.bal
+[Sample](cosmosdb/samples/data-operations/documents/replace_document.bal)
 
 ### Get a document
 This sample shows how to get a document by its ID. It returns ta record of type `Document`. Here, you have to provide 
@@ -459,7 +458,7 @@ session-level consistency level is maintained.
 Users must set this level to the same or weaker level than the account’s configured consistency level. More information 
 about Cosmos DB consistency levels can be found here: https://docs.microsoft.com/en-us/azure/cosmos-db/consistency-levels
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/data-operations/documents/get_document.bal
+[Sample](cosmosdb/samples/data-operations/documents/get_document.bal)
 
 ### List documents
 This sample shows how you can get a list of all the documents. For this operation, you will get a stream of documents 
@@ -506,7 +505,7 @@ session-level consistency level is maintained.
 can be found here: https://docs.microsoft.com/en-us/azure/cosmos-db/change-feed
 - **partitionKeyRangeId** - The partition key range ID for reading data.
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/data-operations/documents/list_documents.bal
+[Sample](cosmosdb/samples/data-operations/documents/list_documents.bal)
 
 ### Delete a document
 This sample shows how to delete a document which exists inside a container. You have to specify the *database ID*, 
@@ -547,10 +546,10 @@ connector. They are related to maintaining the consistency and handling concurre
 - **sessionToken** - the client will use a session token internally with each read/query request to ensure that the 
 session-level consistency level is maintained.
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/data-operations/documents/delete_document.bal
+[Sample](cosmosdb/samples/data-operations/documents/delete_document.bal)
 
 ### Querying documents
-When executing a SQL query using the connector, there are specific ways you can write the query itself. As specified in 
+When executing an SQL query using the connector, there are specific ways you can write the query itself. As specified in 
 the Cosmos DB documentation, SQL queries can be written in different ways for querying Cosmos DB. Cosmos DB Ballerina 
 connector allows the option to either provide a query as a normal ballerina string that matches with the SQL queries 
 compatible with the REST API. This sample shows a query that will return all the data inside a document such that the 
@@ -605,7 +604,7 @@ Notes: <br/>
 - The optional **maxItemCount** parameter specifies the maximum number of results returned per page. So, in the 
 connector, the user can either get the items on one page or get all the results related to each query.
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/data-operations/documents/query_document.bal
+[Sample](cosmosdb/samples/data-operations/documents/query_document.bal)
 
 ## Stored Procedures
 A Stored procedure is a piece of application logic written in JavaScript that is registered and executed against a 
@@ -653,7 +652,7 @@ public function main() {
 }
 ```
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/data-operations/stored-procedure/create_stored_procedure.bal
+[Sample](cosmosdb/samples/data-operations/stored-procedure/create_stored_procedure.bal)
 
 ### Replace a stored procedure
 This sample shows how to replace an existing stored procedure. This new stored procedure enhances the capabilities of 
@@ -697,7 +696,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/data-operations/stored-procedure/replace_stored_procedure.bal
+[Sample](cosmosdb/samples/data-operations/stored-procedure/replace_stored_procedure.bal)
 
 ### List stored procedures
 From this sample, you can get a list of all the stored procedures inside a container. Each record in the result list will 
@@ -736,7 +735,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/data-operations/stored-procedure/list_stored_procedure.bal
+[Sample](cosmosdb/samples/data-operations/stored-procedure/list_stored_procedure.bal)
 
 ### Delete a stored procedure
 This sample shows how to delete a stored procedure that exists inside a container. You have to specify the 
@@ -769,7 +768,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/data-operations/stored-procedure/delete_stored_procedure.bal
+[Sample](cosmosdb/samples/data-operations/stored-procedure/delete_stored_procedure.bal)
 
 ### Execute a stored procedure
 A stored procedure is a piece of logic written in JavaScript which can be executed via an API call. Cosmos DB connector 
@@ -814,7 +813,7 @@ Note: <br/> If a stored procedure contains function arguments to be passed to it
 the `parameters` field of record type `StoredProcedureOptions`. For example, if only one parameter is in the JavaScript 
 function, the argument must be an array with one element as shown in the above sample.
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/data-operations/stored-procedure/execute_stored_procedure.bal
+[Sample](cosmosdb/samples/data-operations/stored-procedure/execute_stored_procedure.bal)
 
 ## Management Plane Operations
 ## Databases
@@ -884,7 +883,7 @@ accounts. For the account type which is called **serverless(preview)** you canno
 not providing support for provisioned throughput for containers or databases inside it.
 More information about serverless accounts can be found here: https://docs.microsoft.com/en-us/azure/cosmos-db/serverless
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/database/create_database.bal
+[Sample](cosmosdb/samples/admin-operations/database/create_database.bal)
 
 ### Get a database
 This operation is related to reading information about a database that is already created inside the Cosmos DB account. 
@@ -917,7 +916,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/database/get_a_database.bal
+[Sample](cosmosdb/samples/admin-operations/database/get_a_database.bal)
 
 ### List All databases
 When there is a need to list down all the databases available inside a Cosmos DB account. This operation will return a 
@@ -950,7 +949,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/database/list_databases.bal
+[Sample](cosmosdb/samples/admin-operations/database/list_databases.bal)
 
 ### Delete a database
 This operation can be used for deleting a database inside an Azure Cosmos DB account. It returns a record of type 
@@ -982,7 +981,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/database/delete_database.bal
+[Sample](cosmosdb/samples/admin-operations/database/delete_database.bal)
 
 ## Containers
 A container in Cosmos DB is schema-agnostic and it is a unit of scalability for the Cosmos DB. It is horizontally 
@@ -1034,7 +1033,7 @@ More information about indexing can be found here: https://docs.microsoft.com/en
 - **throughputOption** - is used in the creation of a container to configure a throughputOption which is an integer value or a 
 record type.
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/container/create_container.bal
+[Sample](cosmosdb/samples/admin-operations/container/create_container.bal)
 ### Get a container
 This operation is related to reading information about a container that is already created inside a database. It mainly 
 returns a record type `Container` which contains the ID of the container, The indexing policy, and the partition key 
@@ -1067,7 +1066,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/container/get_container.bal
+[Sample](cosmosdb/samples/admin-operations/container/get_container.bal)
 
 ### List all containers
 When there is a need to list-down all the containers available inside a database. This operation will return a 
@@ -1106,7 +1105,7 @@ Notes: <br/> The optional parameter `maxItemCount` can be provided as an int to 
 This item count decides the number of items returned per page. If this is not specified the number to return will be 
 100 records per page by default.
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/container/list_containers.bal
+[Sample](cosmosdb/samples/admin-operations/container/list_containers.bal)
 
 ### Delete a container
 This operation can be used for deleting a container inside a database. It returns `DeleteResponse` if the container is 
@@ -1140,7 +1139,7 @@ public function main() {
 }
 ```
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/container/delete_container.bal
+[Sample](cosmosdb/samples/admin-operations/container/delete_container.bal)
 
 ## User Defined Functions
 User-Defined Function - is a side-effect-free piece of application logic written in JavaScript. They can be used to 
@@ -1193,7 +1192,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/user-defined-functions/create_udf.bal
+[Sample](cosmosdb/samples/admin-operations/user-defined-functions/create_udf.bal)
 
 ### Replace a user defined function
 This sample shows how you can replace an existing user defined function with a new one. Here, the name of the User 
@@ -1240,7 +1239,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/user-defined-functions/replace_udf.bal
+[Sample](cosmosdb/samples/admin-operations/user-defined-functions/replace_udf.bal)
 
 ### List user defined functions
 From this sample, you can get a list of all the user defined functions inside a container. The result will 
@@ -1277,7 +1276,7 @@ public function main() {
 }
 ```
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/user-defined-functions/list_udf.bal
+[Sample](cosmosdb/samples/admin-operations/user-defined-functions/list_udf.bal)
 
 ### Delete a user defined function
 This sample shows how to delete a user defined function which exists inside a container. You have to specify the 
@@ -1311,7 +1310,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/user-defined-functions/delete_udf.bal
+[Sample](cosmosdb/samples/admin-operations/user-defined-functions/delete_udf.bal)
 
 ## Triggers
 A Trigger is a piece of application logic that can be executed before (pre-triggers) and after (post-triggers). You can 
@@ -1389,7 +1388,7 @@ Notes: <br/> When creating a trigger, there are several required parameters we h
 - **triggerType** - Specifies when the trigger will be fired, **Pre** or **Post**.
 - **triggerFunction** - The function which will be fired when the trigger is executed.
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/triggers/create_trigger.bal
+[Sample](cosmosdb/samples/admin-operations/triggers/create_trigger.bal)
 
 ### Replace a trigger
 This sample shows how you can replace an existing trigger with a new one. Here, the name of the trigger is updated to a 
@@ -1456,7 +1455,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/triggers/replace_trigger.bal
+[Sample](cosmosdb/samples/admin-operations/triggers/replace_trigger.bal)
 
 ### List triggers
 From this sample, you can get a list of all the triggers inside a container. It will return a stream, which contains 
@@ -1490,7 +1489,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/triggers/list_trigger.bal
+[Sample](cosmosdb/samples/admin-operations/triggers/list_trigger.bal)
 
 ### Delete a trigger
 This sample shows how to delete a trigger that exists inside a container. You have to specify the *database ID*, 
@@ -1524,7 +1523,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/triggers/delete_trigger.bal
+[Sample](cosmosdb/samples/admin-operations/triggers/delete_trigger.bal)
 
 ## Users
 User management operations in Cosmos DB are strictly related with the **Master Key/Primary Key** of the Cosmos DB account. 
@@ -1566,7 +1565,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/users-permissions/user/create_user.bal
+[Sample](cosmosdb/samples/admin-operations/users-permissions/user/create_user.bal)
 
 ### Replace user's ID
 From this sample, you can replace the ID of an existing user. The only replaceable property is the ID of a user created 
@@ -1601,7 +1600,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/users-permissions/user/replace_user_id.bal
+[Sample](cosmosdb/samples/admin-operations/users-permissions/user/replace_user_id.bal)
 
 ### Get a user
 From this sample, you can get the basic information about a created user. For this, the *database ID* where the user is 
@@ -1634,7 +1633,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/users-permissions/user/get_user.bal
+[Sample](cosmosdb/samples/admin-operations/users-permissions/user/get_user.bal)
 
 ### List users
 From this operation, you can get a list of all the users who are scoped into a given database. It will return a stream, 
@@ -1667,7 +1666,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/users-permissions/user/list_users.bal
+[Sample](cosmosdb/samples/admin-operations/users-permissions/user/list_users.bal)
 
 ### Delete a user
 The Common User management operations of databases usually have the option to delete an existing user. The Cosmos DB 
@@ -1700,7 +1699,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/users-permissions/user/delete_user.bal
+[Sample](cosmosdb/samples/admin-operations/users-permissions/user/delete_user.bal)
 
 ## Permissions
 Permissions are related to the Users in the Cosmos DB. The person who possesses the **Master-Token** of the Cosmos DB 
@@ -1709,7 +1708,7 @@ Cosmos DB connector can act as a token broker, which issues tokens with specific
 middle-tier service that serves as the authentication and authorization broker between a client and a back-end service). 
 This is granted by using **Resource-Token**. 
 
-Resource-tokens provide user-based permissions to individual resources in the Cosmos DB database, including collections, 
+Resource-tokens provide user-based permissions to individual resources in the Cosmos DB, including collections, 
 documents, attachments, stored procedures, triggers, and user-defined functions. They are auto-generated when a database 
 user is granted permissions to a resource and re-generated in response to a request referencing that permission. 
 By default, they are **valid for one hour**, with a maximum time-span of five hours. As the use of **Master-Token** 
@@ -1767,7 +1766,7 @@ The **validityPeriodInSeconds** argument can be provided as the last parameter o
 for the token you are creating. This will override the default validity period of the token. The **maximum** override value 
 is **18000 seconds**.
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/users-permissions/permission/create_permission.bal
+[Sample](cosmosdb/samples/admin-operations/users-permissions/permission/create_permission.bal)
 
 ### Replace a permission
 This operation has all the parameters similar to create permission. The only difference is that it only replaces 
@@ -1807,7 +1806,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/users-permissions/permission/replace_permission.bal
+[Sample](cosmosdb/samples/admin-operations/users-permissions/permission/replace_permission.bal)
 
 ### Get a permission
 From this sample, you can get the basic information about a created permission. For this, the *database ID* and the 
@@ -1841,7 +1840,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/users-permissions/permission/get_permission.bal
+[Sample](cosmosdb/samples/admin-operations/users-permissions/permission/get_permission.bal)
 
 ### List permissions
 From this operation, you can get a list of all the permissions that belong to a single user. It will return a stream, 
@@ -1876,7 +1875,7 @@ public function main() {
     }
 }
 ```
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/users-permissions/permission/list_permissions.bal
+[Sample](cosmosdb/samples/admin-operations/users-permissions/permission/list_permissions.bal)
 
 ### Delete a permission
 This Operation allows deleting a permission in the database. For deleting the permission, the specific *database ID*, *user ID* to which the permission belongs and the *ID of the Permission* to delete must be provided.
@@ -1908,7 +1907,7 @@ public function main() {
 }
 ```
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/users-permissions/permission/delete_permission.bal
+[Sample](cosmosdb/samples/admin-operations/users-permissions/permission/delete_permission.bal)
 
 ## Offers
 Cosmos DB containers have either user-defined performance levels or pre-defined performance levels defined for each of 
@@ -1917,7 +1916,7 @@ them. The operations on offers support replacing existing offers, listing and re
 Note: <br/>Operations on offers are not supported in `Serverless` accounts because they don’t specifically have a 
 predefined throughput level.
 
-Sample is available at: https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/samples/admin-operations/offers/offer_operations.bal
+[Sample](cosmosdb/samples/admin-operations/offers/offer_operations.bal)
 
 # Building from the Source
 ## Setting Up the Prerequisites
@@ -1930,11 +1929,11 @@ Sample is available at: https://github.com/ballerina-platform/module-ballerinax-
 
         > **Note:** Set the JAVA_HOME environment variable to the path name of the directory into which you installed JDK.
 
-2. Download and install [Ballerina SL Alpha 5](https://ballerina.io/). 
+2. Download and install [Ballerina SL Beta 1](https://ballerina.io/). 
 
 ## Building the Source
 
-Execute the commands below to build from the source after installing Ballerina SL Alpha 5 version.
+Execute the commands below to build from the source after installing Ballerina SL Beta 1 version.
 
 1. To build the library:
 ```shell script

--- a/cosmosdb/Package.md
+++ b/cosmosdb/Package.md
@@ -2,10 +2,10 @@ Connects to Azure Cosmos DB from Ballerina.
 
 ## Module Overview
 
-The Azure Cosmos DB is Microsoft’s NoSQL database in the Azure technology stack. It is called a globally distributed 
-multi-model database which is used for managing data across the world. The Ballerina Cosmos DB connector allows you to 
-connect to an Azure Cosmos DB resource from Ballerina and perform various operations such as `find`, `create`, `read`, 
-`update`, and `delete` operations of `Databases`, `Containers`,`User Defined Functions`, `Triggers`, `Stored Procedures`, 
+The Azure Cosmos DB is Microsoft’s NoSQL database in the Azure technology stack. It is called a globally distributed
+multi-model database which is used for managing data across the world. The Ballerina Cosmos DB connector allows you to
+connect to an Azure Cosmos DB resource from Ballerina and perform various operations such as `find`, `create`, `read`,
+`update`, and `delete` operations of `Databases`, `Containers`,`User Defined Functions`, `Triggers`, `Stored Procedures`,
 `Users`, `Permissions` and `Offers`.
 
 ## Compatibility
@@ -36,10 +36,10 @@ There are two clients provided by Ballerina to interact with Cosmos DB.
     cosmosdb:ManagementClient managementClient = check new (configuration);
    ```
 
-## Samples 
+## Samples
 ### Creating a Database
-For creating a database in Azure we have to provide a unique database ID that does not already exist in the specific 
-Cosmos DB account. This operation will return a record of type Database. 
+For creating a database in Azure we have to provide a unique database ID that does not already exist in the specific
+Cosmos DB account. This operation will return a record of type Database.
 
 ```ballerina
 import ballerina/log;
@@ -64,9 +64,9 @@ public function main() {
 ```
 
 ### Creating a Container
-A container can be created inside an existing database in the Cosmos DB account. As the REST API version which is used 
-in this implementation of the connector strictly supports the partition key, it is a necessity to provide the 
-partition key in the creation of a container. 
+A container can be created inside an existing database in the Cosmos DB account. As the REST API version which is used
+in this implementation of the connector strictly supports the partition key, it is a necessity to provide the
+partition key in the creation of a container.
 
 ```ballerina
 import ballerina/log;
@@ -96,8 +96,8 @@ public function main() {
 }
 ```
 ### Inserting a Document
-Azure Cosmos DB allows the execution of CRUD operations on items separately. As we are using the Core API underneath the 
-connector, an item may refer to a document in the container. SQL API stores entities as JSON in a hierarchical key-value 
+Azure Cosmos DB allows the execution of CRUD operations on items separately. As we are using the Core API underneath the
+connector, an item may refer to a document in the container. SQL API stores entities as JSON in a hierarchical key-value
 document. The max document size in Cosmos DB is 2 MB.
 ```ballerina
 import ballerina/log;
@@ -129,8 +129,8 @@ public function main() {
 }
 ```
 ### List Documents
-Usually, Cosmos DB provides an array of JSON objects as the response for list operations. But, the connector has handled 
-this array and instead of that, it provides streaming capabilities for these kinds of operations. Apart from 
+Usually, Cosmos DB provides an array of JSON objects as the response for list operations. But, the connector has handled
+this array and instead of that, it provides streaming capabilities for these kinds of operations. Apart from
 that, Cosmos DB originally allows pagination of results returned list operations.
 
 ```ballerina
@@ -144,9 +144,9 @@ public function main() {
     };
     cosmosdb:DataPlaneClient azureCosmosClient = new (configuration);
 
-    stream<cosmosdb:Data, error>|error result = azureCosmosClient->listTriggers(<DATABASE_ID>, <CONTAINER_ID>);
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data document) {
+    stream<cosmosdb:Document, error>|error result = azureCosmosClient->listTriggers(<DATABASE_ID>, <CONTAINER_ID>);
+    if (result is stream<cosmosdb:Document, error>) {
+        error? e = result.forEach(function (cosmosdb:Document document) {
             log:printInfo(document.toString());
         });
         log:printInfo("Success!");
@@ -156,9 +156,9 @@ public function main() {
 }
 ```
 ### Get Document
-This operation allows to retrieve a document by it's ID. It returns a record type `Document`. Here, you have to provide 
-*Database ID*, *Container ID* where the document will be created and the *ID of the document* to retrieve. As the 
-partition key is mandatory in the container, for getDocument operation you need to provide the correct 
+This operation allows to retrieve a document by its ID. It returns a record type `Document`. Here, you have to provide
+*Database ID*, *Container ID* where the document will be created, and the *ID of the document* to retrieve. As the
+partition key is mandatory in the container, for getDocument operation you need to provide the correct
 **value for that partition key**.
 ```ballerina
 import ballerina/log;
@@ -183,8 +183,8 @@ public function main() {
 }
 ```
 ### Query Documents
-Ballerina connector for Azure COsmos DB allows the option to either provide a query as a normal ballerina string that 
-matches with the SQL queries compatible with the REST API. This example shows a query that will return all the data 
+Ballerina connector for Azure Cosmos DB allows the option to either provide a query as a normal ballerina string that
+matches with the SQL queries compatible with the REST API. This example shows a query that will return all the data
 inside a document such that the value for **/gender** equals 0.
 ```ballerina
 import ballerina/log;
@@ -200,11 +200,11 @@ public function main() {
     string selectAllQuery = string `SELECT * FROM ${containerId.toString()} f WHERE f.gender = ${0}`;
     cosmosdb:ResourceQueryOptions options = {partitionKey : 0, enableCrossPartition: false};
 
-    stream<cosmosdb:QueryResult, error>|error result = azureCosmosClient->queryDocuments(<DATABASE_ID>, <CONTAINER_ID>, 
+    stream<cosmosdb:Document, error>|error result = azureCosmosClient->queryDocuments(<DATABASE_ID>, <CONTAINER_ID>, 
         selectAllQuery, options);
 
-    if (result is stream<cosmosdb:QueryResult, error>) {
-        error? e = result.forEach(function (cosmosdb:QueryResult queryResult) {
+    if (result is stream<cosmosdb:Document, error>) {
+        error? e = result.forEach(function (cosmosdb:Document queryResult) {
             log:printInfo(queryResult.toString());
         });
         log:printInfo("Success!");
@@ -215,8 +215,8 @@ public function main() {
 }
 ```
 ### Delete Document
-Using this connector, deletion of a document that exists inside a container is possible. You have to specify the 
-*Database ID*, *Container ID* where the document exists and the *ID of document* you want to delete. The 
+Using this connector, deletion of a document that exists inside a container is possible. You have to specify the
+*Database ID*, *Container ID* where the document exists, and the *ID of document* you want to delete. The
 **value of the partition key** for that specific document should also be passed to the function.
 ```ballerina
 import ballerina/log;
@@ -239,4 +239,4 @@ public function main() {
         log:printInfo("Success!");
     }
 }
-```
+``

--- a/cosmosdb/client_endpoint.bal
+++ b/cosmosdb/client_endpoint.bal
@@ -45,9 +45,9 @@ public client class DataPlaneClient {
     # + documentCreateOptions - The `DocumentCreateOptions` which can be used to add additional capabilities to the 
     #                           request
     # + return - If successful, returns `Document`. Else returns `Error`.
-    @display {label: "Create document"}
-    remote isolated function createDocument(@display {label: "Database Name"} string databaseId, 
-                                            @display {label: "Container Name"} string containerId, 
+    @display {label: "Create Document"}
+    remote isolated function createDocument(@display {label: "Database ID"} string databaseId, 
+                                            @display {label: "Container ID"} string containerId, 
                                             @display {label: "Document"} record {|string id; json...;|} document, 
                                             @display {label: "Partition Key"} int|float|decimal|string partitionKey, 
                                             @display {label: "Optional Header Parameters"} DocumentCreateOptions? 
@@ -74,9 +74,9 @@ public client class DataPlaneClient {
     # + documentReplaceOptions - The `DocumentReplaceOptions` which can be used to add additional capabilities to the 
     #                            request
     # + return - If successful, returns a `Document`. Else returns `Error`.
-    @display {label: "Replace document"}
-    remote isolated function replaceDocument(@display {label: "Database Name"} string databaseId, 
-                                             @display {label: "Container Name"} string containerId, 
+    @display {label: "Replace Document"}
+    remote isolated function replaceDocument(@display {label: "Database ID"} string databaseId, 
+                                             @display {label: "Container ID"} string containerId, 
                                              @display {label: "New Document"} @tainted record {|string id; json...;|} 
                                              document, 
                                              @display {label: "Partition Key"} int|float|decimal|string partitionKey,  
@@ -99,14 +99,14 @@ public client class DataPlaneClient {
     # 
     # + databaseId - ID of the database to which the container belongs to
     # + containerId - ID of the container which contains the document
-    # + documentId - Id of the document 
+    # + documentId - ID of the document 
     # + partitionKey - The value of partition key field of the container
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to the request
     # + return - If successful, returns `Document`. Else returns `Error`.
-    @display {label: "Get document"}
-    remote isolated function getDocument(@display {label: "Database Name"} string databaseId, 
-                                         @display {label: "Container Name"} string containerId, 
-                                         @display {label: "Document Id"} string documentId, 
+    @display {label: "Get Document"}
+    remote isolated function getDocument(@display {label: "Database ID"} string databaseId, 
+                                         @display {label: "Container ID"} string containerId, 
+                                         @display {label: "Document ID"} string documentId, 
                                          @display {label: "Partition Key"} int|float|decimal|string partitionKey, 
                                          @display {label: "Optional Header Parameters"} ResourceReadOptions?
                                          resourceReadOptions = ()) returns @tainted Document|Error { 
@@ -128,9 +128,9 @@ public client class DataPlaneClient {
     # + containerId - ID of the container which contains the document
     # + documentListOptions - The `DocumentListOptions` which can be used to add additional capabilities to the request
     # + return - If successful, returns `stream<Data, error>`. Else, returns `Error`. 
-    @display {label: "Get documents"} 
-    remote isolated function getDocumentList(@display {label: "Database Name"} string databaseId, 
-                                             @display {label: "Container Name"} string containerId, 
+    @display {label: "Get Documents"}
+    remote isolated function getDocumentList(@display {label: "Database ID"} string databaseId, 
+                                             @display {label: "Container ID"} string containerId, 
                                              @display {label: "Optional Header Parameters"} DocumentListOptions? 
                                              documentListOptions = ()) returns 
                                              @tainted @display {label: "Stream of Documents"} stream<Data, error>|Error { 
@@ -154,10 +154,10 @@ public client class DataPlaneClient {
     # + resourceDeleteOptions - The `ResourceDeleteOptions` which can be used to add additional capabilities to the 
     #                           request
     # + return - If successful, returns `DeleteResponse`. Else returns `Error`.
-    @display {label: "Delete document"}
-    remote isolated function deleteDocument(@display {label: "Database Name"} string databaseId, 
-                                            @display {label: "Container Name"} string containerId, 
-                                            @display {label: "Document Id"} string documentId, 
+    @display {label: "Delete Document"}
+    remote isolated function deleteDocument(@display {label: "Database ID"} string databaseId, 
+                                            @display {label: "Container ID"} string containerId, 
+                                            @display {label: "Document ID"} string documentId, 
                                             @display {label: "Partition Key"} int|float|decimal|string partitionKey, 
                                             @display {label: "Optional Header Parameters"} ResourceDeleteOptions? 
                                             resourceDeleteOptions = ()) returns @tainted DeleteResponse|Error { 
@@ -181,9 +181,9 @@ public client class DataPlaneClient {
     # + resourceQueryOptions - The `ResourceQueryOptions` which can be used to add additional capabilities to the 
     #                          request
     # + return - If successful, returns a `stream<QueryResult, error>`. Else returns `Error`.
-    @display {label: "Query documents"}
-    remote isolated function queryDocuments(@display {label: "Database Name"} string databaseId, 
-                                            @display {label: "Container Name"} string containerId, 
+    @display {label: "Query Documents"}
+    remote isolated function queryDocuments(@display {label: "Database ID"} string databaseId, 
+                                            @display {label: "Container ID"} string containerId, 
                                             @display {label: "SQL query"} string sqlQuery, 
                                             @display {label: "Optional Header Parameters"} ResourceQueryOptions? 
                                             resourceQueryOptions = ()) returns 
@@ -216,10 +216,10 @@ public client class DataPlaneClient {
     # + storedProcedureId - A unique ID for the newly created stored procedure
     # + storedProcedure - A JavaScript function represented as a string
     # + return - If successful, returns a `StoredProcedure`. Else returns `Error`. 
-    @display {label: "Create stored procedure"}
-    remote isolated function createStoredProcedure(@display {label: "Database Name"} string databaseId,
-                                                   @display {label: "Container Name"} string containerId,
-                                                   @display {label: "Stored Procedure Id"} string storedProcedureId,
+    @display {label: "Create Stored Procedure"}
+    remote isolated function createStoredProcedure(@display {label: "Database ID"} string databaseId,
+                                                   @display {label: "Container ID"} string containerId,
+                                                   @display {label: "Stored Procedure ID"} string storedProcedureId,
                                                    @display {label: "Stored Procedure Function"} string storedProcedure)
                                                    returns @tainted StoredProcedure|Error {
         http:Request request = new;
@@ -245,10 +245,10 @@ public client class DataPlaneClient {
     # + storedProcedureId - The ID of the stored procedure to be replaced
     # + storedProcedure - A JavaScript function which will replace the existing one
     # + return - If successful, returns a `StoredProcedure`. Else returns `Error`. 
-    @display {label: "Replace stored procedure"} 
-    remote isolated function replaceStoredProcedure(@display {label: "Database Name"} string databaseId, 
-                                                    @display {label: "Container Name"} string containerId, 
-                                                    @display {label: "Stored Procedure Id"} string storedProcedureId, 
+    @display {label: "Replace Stored Procedure"}
+    remote isolated function replaceStoredProcedure(@display {label: "Database ID"} string databaseId, 
+                                                    @display {label: "Container ID"} string containerId, 
+                                                    @display {label: "Stored Procedure ID"} string storedProcedureId, 
                                                     @display {label: "Stored Procedure Function"} string storedProcedure) 
                                                     returns @tainted StoredProcedure|Error { 
         http:Request request = new;
@@ -273,9 +273,9 @@ public client class DataPlaneClient {
     # + containerId - ID of the container which contains the stored procedures
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to the request
     # + return - If successful, returns a `stream<Data, error>`. Else returns `Error`. 
-    @display {label: "Get stored procedures"} 
-    remote isolated function listStoredProcedures(@display {label: "Database Name"} string databaseId, 
-                                                  @display {label: "Container Name"} string containerId, 
+    @display {label: "Get Stored Procedures"}
+    remote isolated function listStoredProcedures(@display {label: "Database ID"} string databaseId, 
+                                                  @display {label: "Container ID"} string containerId, 
                                                   @display {label: "Optional Header Parameters"} ResourceReadOptions?
                                                   resourceReadOptions = ()) returns 
                                                   @tainted @display {label: "Stream of Stored Procedures"} 
@@ -300,10 +300,10 @@ public client class DataPlaneClient {
     # + resourceDeleteOptions - The `ResourceDeleteOptions` which can be used to add additional capabilities to the 
     #                           request
     # + return - If successful, returns `DeleteResponse`. Else returns `Error`.
-    @display {label: "Delete stored procedure"} 
-    remote isolated function deleteStoredProcedure(@display {label: "Database Name"} string databaseId, 
-                                                   @display {label: "Container Name"} string containerId, 
-                                                   @display {label: "Stored Procedure Id"} string storedProcedureId, 
+    @display {label: "Delete Stored Procedure"}
+    remote isolated function deleteStoredProcedure(@display {label: "Database ID"} string databaseId, 
+                                                   @display {label: "Container ID"} string containerId, 
+                                                   @display {label: "Stored Procedure ID"} string storedProcedureId, 
                                                    @display {label: "Optional Header Parameters"} ResourceDeleteOptions? 
                                                    resourceDeleteOptions = ()) returns @tainted DeleteResponse|Error { 
         http:Request request = new;
@@ -325,10 +325,10 @@ public client class DataPlaneClient {
     # + storedProcedureExecuteOptions - A record of type `StoredProcedureExecuteOptions` to specify the additional 
     #                            parameters
     # + return - If successful, returns `json` with the output from the executed function. Else returns `Error`. 
-    @display {label: "Execute stored procedure"} 
-    remote isolated function executeStoredProcedure(@display {label: "Database Name"} string databaseId, 
-                                                    @display {label: "Container Name"} string containerId, 
-                                                    @display {label: "Stored Procedure Id"} string storedProcedureId, 
+    @display {label: "Execute Stored Procedure"}
+    remote isolated function executeStoredProcedure(@display {label: "Database ID"} string databaseId, 
+                                                    @display {label: "Container ID"} string containerId, 
+                                                    @display {label: "Stored Procedure ID"} string storedProcedureId, 
                                                     @display {label: "Execution Options"} 
                                                     StoredProcedureExecuteOptions storedProcedureExecuteOptions) 
                                                     returns @tainted @display {label: "JSON Response"} json|Error { 

--- a/cosmosdb/client_endpoint.bal
+++ b/cosmosdb/client_endpoint.bal
@@ -127,21 +127,21 @@ public client class DataPlaneClient {
     # + databaseId - ID of the database to which the container belongs to
     # + containerId - ID of the container which contains the document
     # + documentListOptions - The `DocumentListOptions` which can be used to add additional capabilities to the request
-    # + return - If successful, returns `stream<Data, error>`. Else, returns `Error`. 
+    # + return - If successful, returns `stream<Document, error>`. Else, returns `Error`. 
     @display {label: "Get Documents"}
     remote isolated function getDocumentList(@display {label: "Database ID"} string databaseId, 
                                              @display {label: "Container ID"} string containerId, 
                                              @display {label: "Optional Header Parameters"} DocumentListOptions? 
                                              documentListOptions = ()) returns 
-                                             @tainted @display {label: "Stream of Documents"} stream<Data, error>|Error { 
+                                             @tainted @display {label: "Stream of Documents"} stream<Document, error>|Error { 
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId, 
             RESOURCE_TYPE_DOCUMENTS]);
         map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET, 
             requestPath);
         headerMap = setOptionalGetHeaders(headerMap, documentListOptions);
 
-        RecordStream objectInstance = check new (self.httpClient, requestPath, headerMap);
-        stream<Data, error> finalStream = new (objectInstance);
+        DocumentStream objectInstance = check new (self.httpClient, requestPath, headerMap);
+        stream<Document, error> finalStream = new (objectInstance);
         return finalStream;
     }
 
@@ -180,15 +180,15 @@ public client class DataPlaneClient {
     # + sqlQuery - A string containing the SQL query
     # + resourceQueryOptions - The `ResourceQueryOptions` which can be used to add additional capabilities to the 
     #                          request
-    # + return - If successful, returns a `stream<QueryResult, error>`. Else returns `Error`.
+    # + return - If successful, returns a `stream<Document, error>`. Else returns `Error`.
     @display {label: "Query Documents"}
     remote isolated function queryDocuments(@display {label: "Database ID"} string databaseId, 
                                             @display {label: "Container ID"} string containerId, 
-                                            @display {label: "SQL query"} string sqlQuery, 
-                                            @display {label: "Optional Header Parameters"} ResourceQueryOptions? 
-                                            resourceQueryOptions = ()) returns 
-                                            @tainted @display {label: "Stream of Documents"} 
-                                            stream<QueryResult, error>|Error { 
+                                            @display {label: "SQL Query"} string sqlQuery,
+                                            @display {label: "Optional Header Parameters"} ResourceQueryOptions?
+                                            resourceQueryOptions = ()) returns
+                                            @tainted @display {label: "Stream of Documents"}
+                                            stream<Document, error>|Error {
         http:Request request = new;
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId,
             RESOURCE_TYPE_DOCUMENTS]);
@@ -203,19 +203,19 @@ public client class DataPlaneClient {
         request.setJsonPayload(<@untainted>payload);
 
         check setHeadersForQuery(request);
-        QueryResultStream objectInstance = check new (self.httpClient, requestPath, request);
-        stream<QueryResult, error> finalStream = new (objectInstance);
+        DocumentQueryResultStream objectInstance = check new (self.httpClient, requestPath, request);
+        stream<Document, error> finalStream = new (objectInstance);
         return finalStream;
     }
 
-    # Create a new stored procedure. Stored Procedure is a piece of application logic written in JavaScript that is 
+    # Create a new stored procedure. Stored Procedure is a piece of application logic written in JavaScript that is
     # registered and executed against a container as a single transaction.
-    # 
+    #
     # + databaseId - ID of the database to which the container belongs to
-    # + containerId - ID of the container where, stored procedure will be created 
+    # + containerId - ID of the container where, stored procedure will be created
     # + storedProcedureId - A unique ID for the newly created stored procedure
     # + storedProcedure - A JavaScript function represented as a string
-    # + return - If successful, returns a `StoredProcedure`. Else returns `Error`. 
+    # + return - If successful, returns a `StoredProcedure`. Else returns `Error`.
     @display {label: "Create Stored Procedure"}
     remote isolated function createStoredProcedure(@display {label: "Database ID"} string databaseId,
                                                    @display {label: "Container ID"} string containerId,
@@ -223,7 +223,7 @@ public client class DataPlaneClient {
                                                    @display {label: "Stored Procedure Function"} string storedProcedure)
                                                    returns @tainted StoredProcedure|Error {
         http:Request request = new;
-        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId, 
+        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId,
             RESOURCE_TYPE_STORED_POCEDURES]);
         check setMandatoryHeaders(request, self.host, self.primaryKeyOrResourceToken, http:HTTP_POST, requestPath);
 
@@ -239,20 +239,20 @@ public client class DataPlaneClient {
     }
 
     # Replace a stored procedure with new one.
-    # 
+    #
     # + databaseId - ID of the database to which the container belongs to
     # + containerId - ID of the container which contains the existing stored procedures
     # + storedProcedureId - The ID of the stored procedure to be replaced
     # + storedProcedure - A JavaScript function which will replace the existing one
-    # + return - If successful, returns a `StoredProcedure`. Else returns `Error`. 
+    # + return - If successful, returns a `StoredProcedure`. Else returns `Error`.
     @display {label: "Replace Stored Procedure"}
-    remote isolated function replaceStoredProcedure(@display {label: "Database ID"} string databaseId, 
-                                                    @display {label: "Container ID"} string containerId, 
-                                                    @display {label: "Stored Procedure ID"} string storedProcedureId, 
-                                                    @display {label: "Stored Procedure Function"} string storedProcedure) 
-                                                    returns @tainted StoredProcedure|Error { 
+    remote isolated function replaceStoredProcedure(@display {label: "Database ID"} string databaseId,
+                                                    @display {label: "Container ID"} string containerId,
+                                                    @display {label: "Stored Procedure ID"} string storedProcedureId,
+                                                    @display {label: "Stored Procedure Function"} string storedProcedure)
+                                                    returns @tainted StoredProcedure|Error {
         http:Request request = new;
-        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId, 
+        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId,
             RESOURCE_TYPE_STORED_POCEDURES, storedProcedureId]);
         check setMandatoryHeaders(request, self.host, self.primaryKeyOrResourceToken, http:HTTP_PUT, requestPath);
 
@@ -268,72 +268,72 @@ public client class DataPlaneClient {
     }
 
     # List information of all stored procedures.
-    # 
+    #
     # + databaseId - ID of the database to which the container belongs to
     # + containerId - ID of the container which contains the stored procedures
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to the request
-    # + return - If successful, returns a `stream<Data, error>`. Else returns `Error`. 
+    # + return - If successful, returns a `stream<StoredProcedure, error>`. Else returns `Error`.
     @display {label: "Get Stored Procedures"}
-    remote isolated function listStoredProcedures(@display {label: "Database ID"} string databaseId, 
-                                                  @display {label: "Container ID"} string containerId, 
+    remote isolated function listStoredProcedures(@display {label: "Database ID"} string databaseId,
+                                                  @display {label: "Container ID"} string containerId,
                                                   @display {label: "Optional Header Parameters"} ResourceReadOptions?
-                                                  resourceReadOptions = ()) returns 
-                                                  @tainted @display {label: "Stream of Stored Procedures"} 
-                                                  stream<Data, error>|Error { 
-        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId, 
+                                                  resourceReadOptions = ()) returns
+                                                  @tainted @display {label: "Stream of Stored Procedures"}
+                                                  stream<StoredProcedure, error>|Error {
+        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId,
             RESOURCE_TYPE_STORED_POCEDURES]);
-        
-        map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET, 
+
+        map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET,
             requestPath);
         headerMap = setOptionalGetHeaders(headerMap, resourceReadOptions);
 
-        RecordStream objectInstance = check new (self.httpClient, requestPath, headerMap);
-        stream<Data, error> finalStream = new (objectInstance);
+        StoredProcedureStream objectInstance = check new (self.httpClient, requestPath, headerMap);
+        stream<StoredProcedure, error> finalStream = new (objectInstance);
         return finalStream;
     }
 
     # Delete a stored procedure.
-    # 
+    #
     # + databaseId - ID of the database to which the container belongs to
     # + containerId - ID of the container which contains the stored procedure
     # + storedProcedureId - ID of the stored procedure to delete
-    # + resourceDeleteOptions - The `ResourceDeleteOptions` which can be used to add additional capabilities to the 
+    # + resourceDeleteOptions - The `ResourceDeleteOptions` which can be used to add additional capabilities to the
     #                           request
     # + return - If successful, returns `DeleteResponse`. Else returns `Error`.
     @display {label: "Delete Stored Procedure"}
-    remote isolated function deleteStoredProcedure(@display {label: "Database ID"} string databaseId, 
-                                                   @display {label: "Container ID"} string containerId, 
-                                                   @display {label: "Stored Procedure ID"} string storedProcedureId, 
-                                                   @display {label: "Optional Header Parameters"} ResourceDeleteOptions? 
-                                                   resourceDeleteOptions = ()) returns @tainted DeleteResponse|Error { 
+    remote isolated function deleteStoredProcedure(@display {label: "Database ID"} string databaseId,
+                                                   @display {label: "Container ID"} string containerId,
+                                                   @display {label: "Stored Procedure ID"} string storedProcedureId,
+                                                   @display {label: "Optional Header Parameters"} ResourceDeleteOptions?
+                                                   resourceDeleteOptions = ()) returns @tainted DeleteResponse|Error {
         http:Request request = new;
-        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId, 
+        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId,
             RESOURCE_TYPE_STORED_POCEDURES, storedProcedureId]);
         check setMandatoryHeaders(request, self.host, self.primaryKeyOrResourceToken, http:HTTP_DELETE, requestPath);
         setOptionalHeaders(request, resourceDeleteOptions);
 
         http:Response response = check self.httpClient->delete(requestPath, request);
         check handleHeaderOnlyResponse(response);
-        return mapHeadersToResultType(response); 
+        return mapHeadersToResultType(response);
     }
 
     # Execute a stored procedure.
-    # 
+    #
     # + databaseId - ID of the database to which the container belongs to
     # + containerId - ID of the container which contains the stored procedure
     # + storedProcedureId - ID of the stored procedure to execute
-    # + storedProcedureExecuteOptions - A record of type `StoredProcedureExecuteOptions` to specify the additional 
+    # + storedProcedureExecuteOptions - A record of type `StoredProcedureExecuteOptions` to specify the additional
     #                            parameters
-    # + return - If successful, returns `json` with the output from the executed function. Else returns `Error`. 
+    # + return - If successful, returns `json` with the output from the executed function. Else returns `Error`.
     @display {label: "Execute Stored Procedure"}
-    remote isolated function executeStoredProcedure(@display {label: "Database ID"} string databaseId, 
-                                                    @display {label: "Container ID"} string containerId, 
-                                                    @display {label: "Stored Procedure ID"} string storedProcedureId, 
-                                                    @display {label: "Execution Options"} 
-                                                    StoredProcedureExecuteOptions storedProcedureExecuteOptions) 
-                                                    returns @tainted @display {label: "JSON Response"} json|Error { 
+    remote isolated function executeStoredProcedure(@display {label: "Database ID"} string databaseId,
+                                                    @display {label: "Container ID"} string containerId,
+                                                    @display {label: "Stored Procedure ID"} string storedProcedureId,
+                                                    @display {label: "Execution Options"}
+                                                    StoredProcedureExecuteOptions storedProcedureExecuteOptions)
+                                                    returns @tainted @display {label: "JSON Response"} json|Error {
         http:Request request = new;
-        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId, 
+        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId,
             RESOURCE_TYPE_STORED_POCEDURES, storedProcedureId]);
         check setMandatoryHeaders(request, self.host, self.primaryKeyOrResourceToken, http:HTTP_POST, requestPath);
         setPartitionKeyHeader(request, storedProcedureExecuteOptions?.partitionKey);

--- a/cosmosdb/management_endpoint.bal
+++ b/cosmosdb/management_endpoint.bal
@@ -147,7 +147,7 @@ public client class ManagementClient {
     # + return - If successful, returns `Container`. Else returns `Error`.
     @display {label: "Create container"} 
     remote isolated function createContainer(@display {label: "Database Name"} string databaseId, 
-                                             @display {label: "Container Name"} string containerId, 
+                                             @display {label: "Container ID"} string containerId, 
                                              @display {label: "Partition Key Definition"} PartitionKey partitionKey, 
                                              @display {label: "Indexing Policy (optional)"} IndexingPolicy? 
                                              indexingPolicy = (), 
@@ -188,7 +188,7 @@ public client class ManagementClient {
     #            Else returns `Error`.
     @display {label: "Create container if not exist"} 
     remote isolated function createContainerIfNotExist(@display {label: "Database Name"} string databaseId, 
-                                                       @display {label: "Container Name"} string containerId, 
+                                                       @display {label: "Container ID"} string containerId, 
                                                        @display {label: "Partition Key Definition"} PartitionKey 
                                                        partitionKey, 
                                                        @display {label: "Indexing Policy (optional)"} IndexingPolicy? 
@@ -213,7 +213,7 @@ public client class ManagementClient {
     # + return - If successful, returns `Container`. Else returns `Error`.
     @display {label: "Get container"} 
     remote isolated function getContainer(@display {label: "Database Name"} string databaseId, 
-                                          @display {label: "Container Name"} string containerId, 
+                                          @display {label: "Container ID"} string containerId, 
                                           @display {label: "Optional Header Parameters"} ResourceReadOptions? 
                                           resourceReadOptions = ()) 
                                           returns @tainted Container|Error {
@@ -254,8 +254,8 @@ public client class ManagementClient {
     #                           request
     # + return - If successful, returns `DeleteResponse`. Else returns `Error`.
     @display {label: "Delete container"} 
-    remote isolated function deleteContainer(@display {label: "Database Name"} string databaseId, 
-                                             @display {label: "Container Name"} string containerId, 
+    remote isolated function deleteContainer(@display {label: "Database ID"} string databaseId, 
+                                             @display {label: "Container ID"} string containerId, 
                                              @display {label: "Optional Header Parameters"} ResourceDeleteOptions? 
                                              resourceDeleteOptions = ()) returns 
                                              @tainted DeleteResponse|Error {
@@ -275,8 +275,8 @@ public client class ManagementClient {
     # + containerId - ID of the container where the partition key ranges are related to
     # + return - If successful, returns `stream<Data, error>`. Else returns `Error`.
     @display {label: "Get partition key ranges"} 
-    remote isolated function listPartitionKeyRanges(@display {label: "Database Name"} string databaseId, 
-                                                    @display {label: "Container Name"} string containerId) returns 
+    remote isolated function listPartitionKeyRanges(@display {label: "Database ID"} string databaseId, 
+                                                    @display {label: "Container ID"} string containerId) returns 
                                                     @tainted @display {label: "Stream of Partition Key Ranges"} 
                                                     stream<Data, error>|Error {
         http:Request request = new;
@@ -299,9 +299,9 @@ public client class ManagementClient {
     # + userDefinedFunction - A JavaScript function represented as a string
     # + return - If successful, returns a `UserDefinedFunction`. Else returns `Error`. 
     @display {label: "Create user defined function"} 
-    remote isolated function createUserDefinedFunction(@display {label: "Database Name"} string databaseId, 
-                                                       @display {label: "Container Name"} string containerId, 
-                                                       @display {label: "User Defined Function Id"} string 
+    remote isolated function createUserDefinedFunction(@display {label: "Database ID"} string databaseId, 
+                                                       @display {label: "Container ID"} string containerId, 
+                                                       @display {label: "User Defined Function ID"} string 
                                                        userDefinedFunctionId, 
                                                        @display {label: "User Defined Function"} string 
                                                        userDefinedFunction) returns 
@@ -330,9 +330,9 @@ public client class ManagementClient {
     # + userDefinedFunction - A JavaScript function represented as a string
     # + return - If successful, returns a `UserDefinedFunction`. Else returns `Error`.
     @display {label: "Replace user defined function"} 
-    remote isolated function replaceUserDefinedFunction(@display {label: "Database Name"} string databaseId, 
-                                                        @display {label: "Container Name"} string containerId, 
-                                                        @display {label: "User Defined Function Id"} string 
+    remote isolated function replaceUserDefinedFunction(@display {label: "Database ID"} string databaseId, 
+                                                        @display {label: "Container ID"} string containerId, 
+                                                        @display {label: "User Defined Function ID"} string 
                                                         userDefinedFunctionId, 
                                                         @display {label: "User Defined Function"} string 
                                                         userDefinedFunction) returns 
@@ -360,8 +360,8 @@ public client class ManagementClient {
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to the request
     # + return - If successful, returns a `stream<Data, error>`. Else returns `Error`. 
     @display {label: "Get user defined functions"} 
-    remote isolated function listUserDefinedFunctions(@display {label: "Database Name"} string databaseId, 
-                                                      @display {label: "Container Name"} string containerId, 
+    remote isolated function listUserDefinedFunctions(@display {label: "Database ID"} string databaseId, 
+                                                      @display {label: "Container ID"} string containerId, 
                                                       @display {label: "Optional Header Parameters"} ResourceReadOptions? 
                                                       resourceReadOptions = ()) returns 
                                                       @tainted @display {label: "Stream of User Defined Fucntions"} 
@@ -382,14 +382,14 @@ public client class ManagementClient {
     # 
     # + databaseId - ID of the database to which the container belongs to
     # + containerId - ID of the container which contains the user defined function
-    # + userDefinedFunctionid - Id of UDF to delete
+    # + userDefinedFunctionid - ID of UDF to delete
     # + resourceDeleteOptions - The `ResourceDeleteOptions` which can be used to add additional capabilities to the 
     #                           request
     # + return - If successful, returns `DeleteResponse`. Else returns `Error`.
     @display {label: "Delete user defined function"} 
-    remote isolated function deleteUserDefinedFunction(@display {label: "Database Name"} string databaseId, 
-                                                       @display {label: "Container Name"} string containerId, 
-                                                       @display {label: "User Defined Function Id"} string 
+    remote isolated function deleteUserDefinedFunction(@display {label: "Database ID"} string databaseId, 
+                                                       @display {label: "Container ID"} string containerId, 
+                                                       @display {label: "User Defined Function ID"} string 
                                                        userDefinedFunctionid, 
                                                        @display {label: "Optional Header Parameters"} 
                                                        ResourceDeleteOptions? resourceDeleteOptions =()) returns
@@ -417,9 +417,9 @@ public client class ManagementClient {
     # + triggerType - The instance in which trigger will be executed `Pre` or `Post`
     # + return - If successful, returns a `Trigger`. Else returns `Error`. 
     @display {label: "Create trigger"} 
-    remote isolated function createTrigger(@display {label: "Database Name"} string databaseId, 
-                                           @display {label: "Container Name"} string containerId, 
-                                           @display {label: "Trigger Id"} string triggerId, 
+    remote isolated function createTrigger(@display {label: "Database ID"} string databaseId, 
+                                           @display {label: "Container ID"} string containerId, 
+                                           @display {label: "Trigger ID"} string triggerId, 
                                            @display {label: "Trigger"} string trigger, 
                                            @display {label: "Triggering Operation"} TriggerOperation triggerOperation, 
                                            @display {label: "Trigger Type"} TriggerType triggerType) returns 
@@ -452,9 +452,9 @@ public client class ManagementClient {
     # + triggerType - The instance in which trigger will be executed `Pre` or `Post`
     # + return - If successful, returns a `Trigger`. Else returns `Error`.
     @display {label: "Replace trigger"} 
-    remote isolated function replaceTrigger(@display {label: "Database Name"} string databaseId, 
-                                            @display {label: "Container Name"} string containerId, 
-                                            @display {label: "Trigger Id"} string triggerId, 
+    remote isolated function replaceTrigger(@display {label: "Database ID"} string databaseId, 
+                                            @display {label: "Container ID"} string containerId, 
+                                            @display {label: "Trigger ID"} string triggerId, 
                                             @display {label: "Trigger"} string trigger, 
                                             @display {label: "Triggering Operation"} TriggerOperation triggerOperation, 
                                             @display {label: "Trigger Type"} TriggerType triggerType) returns 
@@ -484,8 +484,8 @@ public client class ManagementClient {
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to therequest
     # + return - If successful, returns a `stream<Data, error>`. Else returns `Error`. 
     @display {label: "Get triggers"} 
-    remote isolated function listTriggers(@display {label: "Database Name"} string databaseId, 
-                                          @display {label: "Container Name"} string containerId, 
+    remote isolated function listTriggers(@display {label: "Database ID"} string databaseId, 
+                                          @display {label: "Container ID"} string containerId, 
                                           @display {label: "Optional Header Parameters"} ResourceReadOptions?
                                           resourceReadOptions = ()) returns 
                                           @tainted @display {label: "Stream of Triggers"} stream<Data, error>|Error { 
@@ -510,9 +510,9 @@ public client class ManagementClient {
     #                           request
     # + return - If successful, returns `DeleteResponse`. Else returns `Error`.
     @display {label: "Delete trigger"} 
-    remote isolated function deleteTrigger(@display {label: "Database Name"} string databaseId, 
-                                           @display {label: "Container Name"} string containerId, 
-                                           @display {label: "Trigger Id"} string triggerId, 
+    remote isolated function deleteTrigger(@display {label: "Database ID"} string databaseId, 
+                                           @display {label: "Container ID"} string containerId, 
+                                           @display {label: "Trigger ID"} string triggerId, 
                                            @display {label: "Optional Header Parameters"} ResourceDeleteOptions? 
                                            resourceDeleteOptions = ()) returns @tainted DeleteResponse|Error {
         http:Request request = new;
@@ -532,8 +532,8 @@ public client class ManagementClient {
     # + userId - ID of the new user. Must be a unique value.
     # + return - If successful, returns a `User`. Else returns `Error`.
     @display {label: "Create user"} 
-    remote isolated function createUser(@display {label: "Database Name"} string databaseId, 
-                                        @display {label: "User Id"} string userId) returns @tainted User|Error {
+    remote isolated function createUser(@display {label: "Database ID"} string databaseId, 
+                                        @display {label: "User ID"} string userId) returns @tainted User|Error {
         http:Request request = new;
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_USER]);
         check setMandatoryHeaders(request, self.host, self.primaryKeyOrResourceToken, http:HTTP_POST, requestPath);
@@ -551,10 +551,10 @@ public client class ManagementClient {
     # + userId - Old ID of the user
     # + newUserId - New ID for the user
     # + return - If successful, returns a `User`. Else returns `Error`.
-    @display {label: "Replace user Id"} 
+    @display {label: "Replace user ID"} 
     remote isolated function replaceUserId(@display {label: "Database Name"} string databaseId, 
-                                           @display {label: "Old User Id"} string userId, 
-                                           @display {label: "New User Id"} string newUserId) returns 
+                                           @display {label: "Old User ID"} string userId, 
+                                           @display {label: "New User ID"} string newUserId) returns 
                                            @tainted User|Error {
         http:Request request = new;
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_USER, userId]);
@@ -576,7 +576,7 @@ public client class ManagementClient {
     # + return - If successful, returns a `User`. Else returns `Error`.
     @display {label: "Get user"} 
     remote isolated function getUser(@display {label: "Database Name"} string databaseId, 
-                                     @display {label: "User Id"} string userId, 
+                                     @display {label: "User ID"} string userId, 
                                      @display {label: "Optional Header Parameters"} ResourceReadOptions? 
                                      resourceReadOptions = ()) returns @tainted User|Error {
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_USER, userId]);
@@ -620,7 +620,7 @@ public client class ManagementClient {
     # + return - If successful, returns `DeleteResponse`. Else returns `Error`.
     @display {label: "Delete user"} 
     remote isolated function deleteUser(@display {label: "Database Name"} string databaseId, 
-                                        @display {label: "User Id"} string userId, 
+                                        @display {label: "User ID"} string userId, 
                                         @display {label: "Optional Header Parameters"} ResourceDeleteOptions? 
                                         resourceDeleteOptions = ()) returns @tainted DeleteResponse|Error {
         http:Request request = new;
@@ -644,8 +644,8 @@ public client class ManagementClient {
     # + return - If successful, returns a `Permission`. Else returns `Error`.
     @display {label: "Create permission"} 
     remote isolated function createPermission(@display {label: "Database Name"} string databaseId, 
-                                              @display {label: "User Id"} string userId, 
-                                              @display {label: "Permission Id"} string permissionId, 
+                                              @display {label: "User ID"} string userId, 
+                                              @display {label: "Permission ID"} string permissionId, 
                                               @display {label: "Permission Mode"} PermisssionMode permissionMode, 
                                               @display {label: "Resource Path"} string resourcePath, 
                                               @display {label: "Validity Period in Seconds (optional)"} int? 
@@ -681,8 +681,8 @@ public client class ManagementClient {
     # + return - If successful, returns a `Permission`. Else returns `Error`.
     @display {label: "Replace permission"} 
     remote isolated function replacePermission(@display {label: "Database Name"} string databaseId, 
-                                               @display {label: "User Id"} string userId, 
-                                               @display {label: "Permission Id"} string permissionId, 
+                                               @display {label: "User ID"} string userId, 
+                                               @display {label: "Permission ID"} string permissionId, 
                                                @display {label: "Permission Mode"} PermisssionMode permissionMode, 
                                                @display {label: "Resource Path"} string resourcePath, 
                                                @display {label: "Validity Period in Seconds (optional)"} int? 
@@ -716,8 +716,8 @@ public client class ManagementClient {
     # + return - If successful, returns a `Permission`. Else returns `Error`.
     @display {label: "Get permission"} 
     remote isolated function getPermission(@display {label: "Database Name"} string databaseId, 
-                                           @display {label: "User Id"} string userId,
-                                           @display {label: "Permission Id"} string permissionId, 
+                                           @display {label: "User ID"} string userId,
+                                           @display {label: "Permission ID"} string permissionId, 
                                            @display {label: "Optional Header Parameters"} ResourceReadOptions? 
                                            resourceReadOptions = ()) returns @tainted Permission|Error { 
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_USER, userId, 
@@ -740,7 +740,7 @@ public client class ManagementClient {
     # + return - If successful, returns a `stream<Data, error>`. Else returns `Error`.
     @display {label: "Get permissions"} 
     remote isolated function listPermissions(@display {label: "Database Name"} string databaseId, 
-                                             @display {label: "User Id"} string userId, 
+                                             @display {label: "User ID"} string userId, 
                                              @display {label: "Optional Header Parameters"} ResourceReadOptions? 
                                              resourceReadOptions = ()) returns 
                                              @tainted @display {label: "Stream of Permissions"} 
@@ -767,8 +767,8 @@ public client class ManagementClient {
     # + return - If successful, returns `DeleteResponse`. Else returns `Error`.
     @display {label: "Delete permission"} 
     remote isolated function deletePermission(@display {label: "Database Name"} string databaseId, 
-                                              @display {label: "User Id"} string userId, 
-                                              @display {label: "Permission Id"} string permissionId, 
+                                              @display {label: "User ID"} string userId, 
+                                              @display {label: "Permission ID"} string permissionId, 
                                               @display {label: " Optional Header Parameters"} ResourceDeleteOptions? 
                                               resourceDeleteOptions = ()) returns @tainted DeleteResponse|Error { 
         http:Request request = new;
@@ -788,7 +788,7 @@ public client class ManagementClient {
     # + offer - A record of type `Offer`
     # + return - If successful, returns a `Offer`. Else returns `Error`.
     @display {label: "Replace offer"} 
-    remote isolated function replaceOffer(@display {label: "Offer Id"} Offer offer) returns @tainted Offer|Error {
+    remote isolated function replaceOffer(@display {label: "Offer ID"} Offer offer) returns @tainted Offer|Error {
         http:Request request = new;
         string requestPath = prepareUrl([RESOURCE_TYPE_OFFERS, offer.id]);
         check setMandatoryHeaders(request, self.host, self.primaryKeyOrResourceToken, http:HTTP_PUT, requestPath);
@@ -815,8 +815,8 @@ public client class ManagementClient {
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to the request
     # + return - If successful, returns a `Offer`. Else returns `Error`.
     @display {label: "Get offer"} 
-    remote isolated function getOffer(@display {label: "Offer Id"} string offerId, 
-                                      @display {label: " Optional Header Parameters"} ResourceReadOptions? 
+    remote isolated function getOffer(@display {label: "Offer ID"} string offerId, 
+                                      @display {label: "Optional Header Parameters"} ResourceReadOptions? 
                                       resourceReadOptions = ()) returns @tainted Offer|Error {
         string requestPath = prepareUrl([RESOURCE_TYPE_OFFERS, offerId]);
         map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET, 

--- a/cosmosdb/management_endpoint.bal
+++ b/cosmosdb/management_endpoint.bal
@@ -38,8 +38,8 @@ public client class ManagementClient {
     # + databaseId - ID of the new database. Must be a unique value.
     # + throughputOption - Optional. Throughput parameter of type int or json.
     # + return - If successful, returns `Database`. Else returns `Error`.
-    @display {label: "Create database"} 
-    remote isolated function createDatabase(@display {label: "Database Name"} string databaseId, 
+    @display {label: "Create Database"} 
+    remote isolated function createDatabase(@display {label: "Database ID"} string databaseId, 
                                             @display {label: "Maximum Throughput (optional)"} 
                                             (int|record{|int maxThroughput;|})? throughputOption = ()) 
                                             returns @tainted Database|Error {
@@ -57,7 +57,7 @@ public client class ManagementClient {
         http:Response response = check self.httpClient->post(requestPath, request);
         // Return the json payload from the response 
         json jsonResponse = check handleResponse(response);
-        // Map the reponse payload and the headers to a record type
+        // Map the response payload and the headers to a record type
         return mapJsonToDatabaseType(jsonResponse);
     }
 
@@ -66,8 +66,8 @@ public client class ManagementClient {
     # + databaseId - ID of the new database. Must be a unique value.
     # + throughputOption - Optional. Throughput parameter of type int or json.
     # + return - If successful, returns `Database` or `nil` if database already exists. Else returns `Error`.
-    @display {label: "Create database if does not exist"} 
-    remote isolated function createDatabaseIfNotExist(@display {label: "Database Name"} string databaseId, 
+    @display {label: "Create Database If Not Exist"} 
+    remote isolated function createDatabaseIfNotExist(@display {label: "Database ID"} string databaseId, 
                                                       @display {label: "Maximum Throughput (optional)"} 
                                                       (int|record{|int maxThroughput;|})? throughputOption = ()) returns 
                                                       @tainted Database?|Error {
@@ -85,8 +85,8 @@ public client class ManagementClient {
     # + databaseId - ID of the database 
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to the request
     # + return - If successful, returns `Database`. Else returns `Error`.
-    @display {label: "Get database"} 
-    remote isolated function getDatabase(@display {label: "Database Name"} string databaseId, 
+    @display {label: "Get Database"} 
+    remote isolated function getDatabase(@display {label: "Database ID"} string databaseId, 
                                          @display {label: "Optional Header Parameters"} ResourceReadOptions? 
                                          resourceReadOptions = ()) 
                                          returns @tainted Database|Error {
@@ -102,30 +102,31 @@ public client class ManagementClient {
 
     # List information of all databases.
     # 
-    # + return - If successful, returns `stream<Data, error>`. else returns `Error`.
-    @display {label: "Get databases"}  
-    remote isolated function listDatabases() returns 
-                                          @tainted @display {label: "Stream of Databases"} stream<Data, error>|Error {
+    # + return - If successful, returns `stream<Database, error>`. else returns `Error`.
+    @display {label: "Get Databases"}
+    remote isolated function listDatabases() returns
+                                          @tainted @display {label: "Stream of Databases"}
+                                          stream<Database, error>|Error {
         http:Request request = new;
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES]);
 
-        map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET, 
+        map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET,
             requestPath);
 
-        RecordStream objectInstance = check new (self.httpClient, requestPath, headerMap);
-        stream<Data, error> finalStream = new (objectInstance);
+        DatabaseStream objectInstance = check new (self.httpClient, requestPath, headerMap);
+        stream<Database, error> finalStream = new (objectInstance);
         return finalStream;
     }
 
     # Delete a given database.
-    # 
+    #
     # + databaseId - ID of the database to delete
-    # + resourceDeleteOptions - The `ResourceDeleteOptions` which can be used to add additional capabilities 
+    # + resourceDeleteOptions - The `ResourceDeleteOptions` which can be used to add additional capabilities
     #                           to the request
     # + return - If successful, returns `DeleteResponse`. Else returns `Error`.
-    @display {label: "Delete a database"} 
-    remote isolated function deleteDatabase(@display {label: "Database Name"} string databaseId, 
-                                            @display {label: "Optional Header Parameters"} ResourceDeleteOptions? 
+    @display {label: "Delete Database"}
+    remote isolated function deleteDatabase(@display {label: "Database ID"} string databaseId,
+                                            @display {label: "Optional Header Parameters"} ResourceDeleteOptions?
                                             resourceDeleteOptions = ()) returns @tainted DeleteResponse|Error {
         http:Request request = new;
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId]);
@@ -134,26 +135,26 @@ public client class ManagementClient {
 
         http:Response response = check self.httpClient->delete(requestPath, request);
         check handleHeaderOnlyResponse(response);
-        return mapHeadersToResultType(response); 
+        return mapHeadersToResultType(response);
     }
 
     # Create a container inside the given database.
-    # 
+    #
     # + databaseId - ID of the database to which the container belongs to
     # + containerId - ID of the new container. Must be a unique value.
     # + partitionKey - A record of type `PartitionKey`
     # + indexingPolicy - Optional. A record of type `IndexingPolicy`.
     # + throughputOption - Optional. Throughput parameter of type int or json.
     # + return - If successful, returns `Container`. Else returns `Error`.
-    @display {label: "Create container"} 
-    remote isolated function createContainer(@display {label: "Database Name"} string databaseId, 
-                                             @display {label: "Container ID"} string containerId, 
-                                             @display {label: "Partition Key Definition"} PartitionKey partitionKey, 
-                                             @display {label: "Indexing Policy (optional)"} IndexingPolicy? 
-                                             indexingPolicy = (), 
-                                             @display {label: "Maximum Throughput (optional)"} 
-                                             (int|record{|int maxThroughput;|})? throughputOption = ()) returns 
-                                             @tainted Container|Error { 
+    @display {label: "Create Container"}
+    remote isolated function createContainer(@display {label: "Database ID"} string databaseId,
+                                             @display {label: "Container ID"} string containerId,
+                                             @display {label: "Partition Key Definition"} PartitionKey partitionKey,
+                                             @display {label: "Indexing Policy (optional)"} IndexingPolicy?
+                                             indexingPolicy = (),
+                                             @display {label: "Maximum Throughput (optional)"}
+                                             (int|record{|int maxThroughput;|})? throughputOption = ()) returns
+                                             @tainted Container|Error {
         http:Request request = new;
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS]);
         check setMandatoryHeaders(request, self.host, self.primaryKeyOrResourceToken, http:HTTP_POST, requestPath);
@@ -178,24 +179,24 @@ public client class ManagementClient {
     }
 
     # Create a container only if the specified container ID does not exist already.
-    # 
+    #
     # + databaseId - ID of the database to which the container belongs to
     # + containerId - ID of the new container
     # + partitionKey - A record of type `PartitionKey`
     # + indexingPolicy - Optional. A record of type `IndexingPolicy`.
     # + throughputOption - Optional. Throughput parameter of type int or json.
-    # + return - If successful, returns `Container` if a new container is created or `nil` if container already exists. 
+    # + return - If successful, returns `Container` if a new container is created or `nil` if container already exists.
     #            Else returns `Error`.
-    @display {label: "Create container if not exist"} 
-    remote isolated function createContainerIfNotExist(@display {label: "Database Name"} string databaseId, 
-                                                       @display {label: "Container ID"} string containerId, 
-                                                       @display {label: "Partition Key Definition"} PartitionKey 
-                                                       partitionKey, 
-                                                       @display {label: "Indexing Policy (optional)"} IndexingPolicy? 
-                                                       indexingPolicy = (), 
-                                                       @display {label: "Maximum Throughput (optional)"} 
-                                                       (int|record{|int maxThroughput;|})? throughputOption = ()) 
-                                                       returns @tainted Container?|Error { 
+    @display {label: "Create Container If Not Exist"}
+    remote isolated function createContainerIfNotExist(@display {label: "Database ID"} string databaseId,
+                                                       @display {label: "Container ID"} string containerId,
+                                                       @display {label: "Partition Key Definition"} PartitionKey
+                                                       partitionKey,
+                                                       @display {label: "Indexing Policy (optional)"} IndexingPolicy?
+                                                       indexingPolicy = (),
+                                                       @display {label: "Maximum Throughput (optional)"}
+                                                       (int|record{|int maxThroughput;|})? throughputOption = ())
+                                                       returns @tainted Container?|Error {
         var result = self->createContainer(databaseId, containerId, partitionKey, indexingPolicy, throughputOption);
         if (result is error<HttpDetail>) {
             if (result.detail().status == http:STATUS_CONFLICT) {
@@ -206,19 +207,19 @@ public client class ManagementClient {
     }
 
     # Get information about a container.
-    # 
+    #
     # + databaseId - ID of the database to which the container belongs to
     # + containerId - ID of the container
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to the request
     # + return - If successful, returns `Container`. Else returns `Error`.
-    @display {label: "Get container"} 
-    remote isolated function getContainer(@display {label: "Database Name"} string databaseId, 
-                                          @display {label: "Container ID"} string containerId, 
-                                          @display {label: "Optional Header Parameters"} ResourceReadOptions? 
-                                          resourceReadOptions = ()) 
+    @display {label: "Get Container"}
+    remote isolated function getContainer(@display {label: "Database ID"} string databaseId,
+                                          @display {label: "Container ID"} string containerId,
+                                          @display {label: "Optional Header Parameters"} ResourceReadOptions?
+                                          resourceReadOptions = ())
                                           returns @tainted Container|Error {
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId]);
-        map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET, 
+        map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET,
             requestPath);
         headerMap = setOptionalGetHeaders(headerMap, resourceReadOptions);
 
@@ -228,36 +229,36 @@ public client class ManagementClient {
     }
 
     # List information of all containers.
-    # 
+    #
     # + databaseId - ID of the database to which the containers belongs to
-    # + return - If successful, returns `stream<Data, error>`. Else returns `Error`.
-    @display {label: "Get containers"} 
-    remote isolated function listContainers(@display {label: "Database Name"} string databaseId) 
-                                            returns @tainted @display {label: "Stream of Containers"} 
-                                            stream<Data, error>|Error {
+    # + return - If successful, returns `stream<Container, error>`. Else returns `Error`.
+    @display {label: "Get Containers"}
+    remote isolated function listContainers(@display {label: "Database ID"} string databaseId)
+                                            returns @tainted @display {label: "Stream of Containers"}
+                                            stream<Container, error>|Error {
         http:Request request = new;
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS]);
 
-        map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET, 
+        map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET,
             requestPath);
 
-        RecordStream objectInstance = check new (self.httpClient, requestPath, headerMap);
-        stream<Data, error> finalStream = new (objectInstance);
+        ContainerStream objectInstance = check new (self.httpClient, requestPath, headerMap);
+        stream<Container, error> finalStream = new (objectInstance);
         return finalStream;
     }
 
     # Delete a container.
-    # 
+    #
     # + databaseId - ID of the database to which the container belongs to
     # + containerId - ID of the container to delete
-    # + resourceDeleteOptions - The `ResourceDeleteOptions` which can be used to add additional capabilities to the 
+    # + resourceDeleteOptions - The `ResourceDeleteOptions` which can be used to add additional capabilities to the
     #                           request
     # + return - If successful, returns `DeleteResponse`. Else returns `Error`.
-    @display {label: "Delete container"} 
-    remote isolated function deleteContainer(@display {label: "Database ID"} string databaseId, 
-                                             @display {label: "Container ID"} string containerId, 
-                                             @display {label: "Optional Header Parameters"} ResourceDeleteOptions? 
-                                             resourceDeleteOptions = ()) returns 
+    @display {label: "Delete Container"}
+    remote isolated function deleteContainer(@display {label: "Database ID"} string databaseId,
+                                             @display {label: "Container ID"} string containerId,
+                                             @display {label: "Optional Header Parameters"} ResourceDeleteOptions?
+                                             resourceDeleteOptions = ()) returns
                                              @tainted DeleteResponse|Error {
         http:Request request = new;
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId]);
@@ -266,48 +267,48 @@ public client class ManagementClient {
 
         http:Response response = check self.httpClient->delete(requestPath, request);
         check handleHeaderOnlyResponse(response);
-        return mapHeadersToResultType(response); 
+        return mapHeadersToResultType(response);
     }
 
     # Retrieve a list of partition key ranges for the container.
-    # 
+    #
     # + databaseId - ID of the database to which the container belongs to
     # + containerId - ID of the container where the partition key ranges are related to
-    # + return - If successful, returns `stream<Data, error>`. Else returns `Error`.
-    @display {label: "Get partition key ranges"} 
-    remote isolated function listPartitionKeyRanges(@display {label: "Database ID"} string databaseId, 
-                                                    @display {label: "Container ID"} string containerId) returns 
-                                                    @tainted @display {label: "Stream of Partition Key Ranges"} 
-                                                    stream<Data, error>|Error {
+    # + return - If successful, returns `stream<PartitionKeyRange, error>`. Else returns `Error`.
+    @display {label: "Get Partition Key Ranges"}
+    remote isolated function listPartitionKeyRanges(@display {label: "Database ID"} string databaseId,
+                                                    @display {label: "Container ID"} string containerId) returns
+                                                    @tainted @display {label: "Stream of Partition Key Ranges"}
+                                                    stream<PartitionKeyRange, error>|Error {
         http:Request request = new;
-        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId, 
+        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId,
             RESOURCE_TYPE_PK_RANGES]);
-        map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET, 
+        map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET,
             requestPath);
 
-        RecordStream objectInstance = check new (self.httpClient, requestPath, headerMap);
-        stream<Data, error> finalStream = new (objectInstance);
+        PartitionKeyRangeStream objectInstance = check new (self.httpClient, requestPath, headerMap);
+        stream<PartitionKeyRange, error> finalStream = new (objectInstance);
         return finalStream;
     }
 
-    # Create a new user defined function. A user defined function is a side effect free piece of application logic 
-    # written in JavaScript. 
-    # 
+    # Create a new User Defined Function. A User Defined Function is a side effect free piece of application logic
+    # written in JavaScript.
+    #
     # + databaseId - ID of the database to which the container belongs to
-    # + containerId - ID of the container where, user defined function is created
-    # + userDefinedFunctionId - A unique ID for the newly created user defined function
+    # + containerId - ID of the container where, User Defined Function is created
+    # + userDefinedFunctionId - A unique ID for the newly created User Defined Function
     # + userDefinedFunction - A JavaScript function represented as a string
-    # + return - If successful, returns a `UserDefinedFunction`. Else returns `Error`. 
-    @display {label: "Create user defined function"} 
-    remote isolated function createUserDefinedFunction(@display {label: "Database ID"} string databaseId, 
-                                                       @display {label: "Container ID"} string containerId, 
-                                                       @display {label: "User Defined Function ID"} string 
-                                                       userDefinedFunctionId, 
-                                                       @display {label: "User Defined Function"} string 
-                                                       userDefinedFunction) returns 
-                                                       @tainted  UserDefinedFunction|Error { 
+    # + return - If successful, returns a `UserDefinedFunction`. Else returns `Error`.
+    @display {label: "Create User Defined Function"}
+    remote isolated function createUserDefinedFunction(@display {label: "Database ID"} string databaseId,
+                                                       @display {label: "Container ID"} string containerId,
+                                                       @display {label: "User Defined Function ID"} string
+                                                       userDefinedFunctionId,
+                                                       @display {label: "User Defined Function"} string
+                                                       userDefinedFunction) returns
+                                                       @tainted  UserDefinedFunction|Error {
         http:Request request = new;
-        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId, 
+        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId,
             RESOURCE_TYPE_UDF]);
         check setMandatoryHeaders(request, self.host, self.primaryKeyOrResourceToken, http:HTTP_POST, requestPath);
 
@@ -315,30 +316,30 @@ public client class ManagementClient {
             id: userDefinedFunctionId,
             body: userDefinedFunction
         };
-        request.setJsonPayload(payload); 
+        request.setJsonPayload(payload);
 
         http:Response response = check self.httpClient->post(requestPath, request);
         json jsonResponse = check handleResponse(response);
         return mapJsonToUserDefinedFunction(jsonResponse);
     }
 
-    # Replace an existing user defined function.
-    # 
+    # Replace an existing User Defined Function.
+    #
     # + databaseId - ID of the database to which the container belongs to
-    # + containerId - ID of the container which contains the existing user defined function
-    # + userDefinedFunctionId - The ID of the user defined function to replace
+    # + containerId - ID of the container which contains the existing User Defined Function
+    # + userDefinedFunctionId - The ID of the User Defined Function to replace
     # + userDefinedFunction - A JavaScript function represented as a string
     # + return - If successful, returns a `UserDefinedFunction`. Else returns `Error`.
-    @display {label: "Replace user defined function"} 
-    remote isolated function replaceUserDefinedFunction(@display {label: "Database ID"} string databaseId, 
-                                                        @display {label: "Container ID"} string containerId, 
-                                                        @display {label: "User Defined Function ID"} string 
-                                                        userDefinedFunctionId, 
-                                                        @display {label: "User Defined Function"} string 
-                                                        userDefinedFunction) returns 
-                                                        @tainted UserDefinedFunction|Error { 
+    @display {label: "Replace User Defined Function"}
+    remote isolated function replaceUserDefinedFunction(@display {label: "Database ID"} string databaseId,
+                                                        @display {label: "Container ID"} string containerId,
+                                                        @display {label: "User Defined Function ID"} string
+                                                        userDefinedFunctionId,
+                                                        @display {label: "User Defined Function"} string
+                                                        userDefinedFunction) returns
+                                                        @tainted UserDefinedFunction|Error {
         http:Request request = new;
-        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId, 
+        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId,
             RESOURCE_TYPE_UDF, userDefinedFunctionId]);
         check setMandatoryHeaders(request, self.host, self.primaryKeyOrResourceToken, http:HTTP_PUT, requestPath);
 
@@ -346,86 +347,86 @@ public client class ManagementClient {
             id: userDefinedFunctionId,
             body: userDefinedFunction
         };
-        request.setJsonPayload(<@untainted>payload); 
+        request.setJsonPayload(<@untainted>payload);
 
         http:Response response = check self.httpClient->put(requestPath, request);
         json jsonResponse = check handleResponse(response);
-        return mapJsonToUserDefinedFunction(jsonResponse); 
+        return mapJsonToUserDefinedFunction(jsonResponse);
     }
 
     # Get a list of existing user defined functions.
-    # 
+    #
     # + databaseId - ID of the database to which the container belongs to
     # + containerId - ID of the container which contains the user defined functions
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to the request
-    # + return - If successful, returns a `stream<Data, error>`. Else returns `Error`. 
-    @display {label: "Get user defined functions"} 
-    remote isolated function listUserDefinedFunctions(@display {label: "Database ID"} string databaseId, 
-                                                      @display {label: "Container ID"} string containerId, 
-                                                      @display {label: "Optional Header Parameters"} ResourceReadOptions? 
-                                                      resourceReadOptions = ()) returns 
-                                                      @tainted @display {label: "Stream of User Defined Fucntions"} 
-                                                      stream<Data, error>|Error { 
-        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId, 
+    # + return - If successful, returns a `stream<UserDefinedFunction, error>`. Else returns `Error`.
+    @display {label: "Get User Defined Functions"}
+    remote isolated function listUserDefinedFunctions(@display {label: "Database ID"} string databaseId,
+                                                      @display {label: "Container ID"} string containerId,
+                                                      @display {label: "Optional Header Parameters"} ResourceReadOptions?
+                                                      resourceReadOptions = ()) returns
+                                                      @tainted @display {label: "Stream of User Defined Fucntions"}
+                                                      stream<UserDefinedFunction, error>|Error {
+        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId,
             RESOURCE_TYPE_UDF]);
 
-        map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET, 
+        map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET,
             requestPath);
         headerMap = setOptionalGetHeaders(headerMap, resourceReadOptions);
 
-        RecordStream objectInstance = check new (self.httpClient, requestPath, headerMap);
-        stream<Data, error> finalStream = new (objectInstance);
+        UserDefiinedFunctionStream objectInstance = check new (self.httpClient, requestPath, headerMap);
+        stream<UserDefinedFunction, error> finalStream = new (objectInstance);
         return finalStream;
     }
 
-    # Delete an existing user defined function.
-    # 
+    # Delete an existing User Defined Function.
+    #
     # + databaseId - ID of the database to which the container belongs to
-    # + containerId - ID of the container which contains the user defined function
+    # + containerId - ID of the container which contains the User Defined Function
     # + userDefinedFunctionid - ID of UDF to delete
-    # + resourceDeleteOptions - The `ResourceDeleteOptions` which can be used to add additional capabilities to the 
+    # + resourceDeleteOptions - The `ResourceDeleteOptions` which can be used to add additional capabilities to the
     #                           request
     # + return - If successful, returns `DeleteResponse`. Else returns `Error`.
-    @display {label: "Delete user defined function"} 
-    remote isolated function deleteUserDefinedFunction(@display {label: "Database ID"} string databaseId, 
-                                                       @display {label: "Container ID"} string containerId, 
-                                                       @display {label: "User Defined Function ID"} string 
-                                                       userDefinedFunctionid, 
-                                                       @display {label: "Optional Header Parameters"} 
+    @display {label: "Delete User Defined Function"}
+    remote isolated function deleteUserDefinedFunction(@display {label: "Database ID"} string databaseId,
+                                                       @display {label: "Container ID"} string containerId,
+                                                       @display {label: "User Defined Function ID"} string
+                                                       userDefinedFunctionid,
+                                                       @display {label: "Optional Header Parameters"}
                                                        ResourceDeleteOptions? resourceDeleteOptions =()) returns
                                                        @tainted DeleteResponse|Error {
         http:Request request = new;
-        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId, 
+        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId,
             RESOURCE_TYPE_UDF, userDefinedFunctionid]);
         check setMandatoryHeaders(request, self.host, self.primaryKeyOrResourceToken, http:HTTP_DELETE, requestPath);
         setOptionalHeaders(request, resourceDeleteOptions);
 
         http:Response response = check self.httpClient->delete(requestPath, request);
         check handleHeaderOnlyResponse(response);
-        return mapHeadersToResultType(response); 
+        return mapHeadersToResultType(response);
     }
 
-    # Create a trigger. Triggers are pieces of application logic that can be executed before (pre-triggers) and 
+    # Create a trigger. Triggers are pieces of application logic that can be executed before (pre-triggers) and
     # after (post-triggers) creation, deletion, and replacement of a document. Triggers are written in JavaScript.
     #
     # + databaseId - ID of the database to which the container belongs to
     # + containerId - ID of the container where trigger is created
     # + triggerId - A unique ID for the newly created trigger
     # + trigger - A JavaScript function represented as a string
-    # + triggerOperation - The specific operation in which trigger will be executed can be `All`, `Create`, `Replace` or 
+    # + triggerOperation - The specific operation in which trigger will be executed can be `All`, `Create`, `Replace` or
     #                      `Delete`
     # + triggerType - The instance in which trigger will be executed `Pre` or `Post`
-    # + return - If successful, returns a `Trigger`. Else returns `Error`. 
-    @display {label: "Create trigger"} 
-    remote isolated function createTrigger(@display {label: "Database ID"} string databaseId, 
-                                           @display {label: "Container ID"} string containerId, 
-                                           @display {label: "Trigger ID"} string triggerId, 
-                                           @display {label: "Trigger"} string trigger, 
-                                           @display {label: "Triggering Operation"} TriggerOperation triggerOperation, 
-                                           @display {label: "Trigger Type"} TriggerType triggerType) returns 
-                                           @tainted Trigger|Error { 
+    # + return - If successful, returns a `Trigger`. Else returns `Error`.
+    @display {label: "Create Trigger"}
+    remote isolated function createTrigger(@display {label: "Database ID"} string databaseId,
+                                           @display {label: "Container ID"} string containerId,
+                                           @display {label: "Trigger ID"} string triggerId,
+                                           @display {label: "Trigger"} string trigger,
+                                           @display {label: "Triggering Operation"} TriggerOperation triggerOperation,
+                                           @display {label: "Trigger Type"} TriggerType triggerType) returns
+                                           @tainted Trigger|Error {
         http:Request request = new;
-        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId, 
+        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId,
             RESOURCE_TYPE_TRIGGER]);
         check setMandatoryHeaders(request, self.host, self.primaryKeyOrResourceToken, http:HTTP_POST, requestPath);
 
@@ -435,15 +436,15 @@ public client class ManagementClient {
             triggerOperation: triggerOperation,
             triggerType: triggerType
         };
-        request.setJsonPayload(payload); 
-        
+        request.setJsonPayload(payload);
+
         http:Response response = check self.httpClient->post(requestPath, request);
         json jsonResponse = check handleResponse(response);
         return mapJsonToTrigger(jsonResponse);
     }
 
     # Replace an existing trigger.
-    # 
+    #
     # + databaseId - ID of the database to which the container belongs to
     # + containerId - ID of the container which contains the trigger
     # + triggerId - The ID of the trigger to be replaced
@@ -451,16 +452,16 @@ public client class ManagementClient {
     # + triggerOperation - The specific operation in which trigger will be executed
     # + triggerType - The instance in which trigger will be executed `Pre` or `Post`
     # + return - If successful, returns a `Trigger`. Else returns `Error`.
-    @display {label: "Replace trigger"} 
-    remote isolated function replaceTrigger(@display {label: "Database ID"} string databaseId, 
-                                            @display {label: "Container ID"} string containerId, 
-                                            @display {label: "Trigger ID"} string triggerId, 
-                                            @display {label: "Trigger"} string trigger, 
-                                            @display {label: "Triggering Operation"} TriggerOperation triggerOperation, 
-                                            @display {label: "Trigger Type"} TriggerType triggerType) returns 
+    @display {label: "Replace Trigger"}
+    remote isolated function replaceTrigger(@display {label: "Database ID"} string databaseId,
+                                            @display {label: "Container ID"} string containerId,
+                                            @display {label: "Trigger ID"} string triggerId,
+                                            @display {label: "Trigger"} string trigger,
+                                            @display {label: "Triggering Operation"} TriggerOperation triggerOperation,
+                                            @display {label: "Trigger Type"} TriggerType triggerType) returns
                                             @tainted Trigger|Error {
         http:Request request = new;
-        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId, 
+        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId,
             RESOURCE_TYPE_TRIGGER, triggerId]);
         check setMandatoryHeaders(request, self.host, self.primaryKeyOrResourceToken, http:HTTP_PUT, requestPath);
 
@@ -471,68 +472,68 @@ public client class ManagementClient {
             triggerType: triggerType
         };
         request.setJsonPayload(<@untainted>payload);
-        
+
         http:Response response = check self.httpClient->put(requestPath, request);
         json jsonResponse = check handleResponse(response);
         return mapJsonToTrigger(jsonResponse);
     }
 
     # List existing triggers.
-    # 
+    #
     # + databaseId - ID of the database to which the container belongs to
     # + containerId - ID of the container which contains the triggers
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to therequest
-    # + return - If successful, returns a `stream<Data, error>`. Else returns `Error`. 
-    @display {label: "Get triggers"} 
-    remote isolated function listTriggers(@display {label: "Database ID"} string databaseId, 
-                                          @display {label: "Container ID"} string containerId, 
+    # + return - If successful, returns a `stream<Trigger, error>`. Else returns `Error`.
+    @display {label: "Get Triggers"}
+    remote isolated function listTriggers(@display {label: "Database ID"} string databaseId,
+                                          @display {label: "Container ID"} string containerId,
                                           @display {label: "Optional Header Parameters"} ResourceReadOptions?
-                                          resourceReadOptions = ()) returns 
-                                          @tainted @display {label: "Stream of Triggers"} stream<Data, error>|Error { 
-        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId, 
+                                          resourceReadOptions = ()) returns
+                                          @tainted @display {label: "Stream of Triggers"} stream<Trigger, error>|Error {
+        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId,
             RESOURCE_TYPE_TRIGGER]);
 
-        map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET, 
+        map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET,
             requestPath);
         headerMap = setOptionalGetHeaders(headerMap, resourceReadOptions);
 
-        RecordStream objectInstance = check new (self.httpClient, requestPath, headerMap);
-        stream<Data, error> finalStream = new (objectInstance);
+        TriggerStream objectInstance = check new (self.httpClient, requestPath, headerMap);
+        stream<Trigger, error> finalStream = new (objectInstance);
         return finalStream;
     }
 
     # Delete an existing trigger.
-    # 
+    #
     # + databaseId - ID of the database to which the container belongs to
     # + containerId - ID of the container which contains the trigger
     # + triggerId - ID of the trigger to be deleted
-    # + resourceDeleteOptions - The `ResourceDeleteOptions` which can be used to add additional capabilities to the 
+    # + resourceDeleteOptions - The `ResourceDeleteOptions` which can be used to add additional capabilities to the
     #                           request
     # + return - If successful, returns `DeleteResponse`. Else returns `Error`.
-    @display {label: "Delete trigger"} 
-    remote isolated function deleteTrigger(@display {label: "Database ID"} string databaseId, 
-                                           @display {label: "Container ID"} string containerId, 
-                                           @display {label: "Trigger ID"} string triggerId, 
-                                           @display {label: "Optional Header Parameters"} ResourceDeleteOptions? 
+    @display {label: "Delete Trigger"}
+    remote isolated function deleteTrigger(@display {label: "Database ID"} string databaseId,
+                                           @display {label: "Container ID"} string containerId,
+                                           @display {label: "Trigger ID"} string triggerId,
+                                           @display {label: "Optional Header Parameters"} ResourceDeleteOptions?
                                            resourceDeleteOptions = ()) returns @tainted DeleteResponse|Error {
         http:Request request = new;
-        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId, 
+        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_COLLECTIONS, containerId,
             RESOURCE_TYPE_TRIGGER, triggerId]);
         check setMandatoryHeaders(request, self.host, self.primaryKeyOrResourceToken, http:HTTP_DELETE, requestPath);
         setOptionalHeaders(request, resourceDeleteOptions);
 
         http:Response response = check self.httpClient->delete(requestPath, request);
         check handleHeaderOnlyResponse(response);
-        return mapHeadersToResultType(response); 
+        return mapHeadersToResultType(response);
     }
 
     # Create a user for a given database.
-    # 
+    #
     # + databaseId - ID of the database where the user is created.
     # + userId - ID of the new user. Must be a unique value.
     # + return - If successful, returns a `User`. Else returns `Error`.
-    @display {label: "Create user"} 
-    remote isolated function createUser(@display {label: "Database ID"} string databaseId, 
+    @display {label: "Create User"}
+    remote isolated function createUser(@display {label: "Database ID"} string databaseId,
                                         @display {label: "User ID"} string userId) returns @tainted User|Error {
         http:Request request = new;
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_USER]);
@@ -546,15 +547,15 @@ public client class ManagementClient {
     }
 
     # Replace the ID of an existing user.
-    # 
+    #
     # + databaseId - ID of the database to which, the existing user belongs to
     # + userId - Old ID of the user
     # + newUserId - New ID for the user
     # + return - If successful, returns a `User`. Else returns `Error`.
-    @display {label: "Replace user ID"} 
-    remote isolated function replaceUserId(@display {label: "Database Name"} string databaseId, 
-                                           @display {label: "Old User ID"} string userId, 
-                                           @display {label: "New User ID"} string newUserId) returns 
+    @display {label: "Replace User ID"}
+    remote isolated function replaceUserId(@display {label: "Database ID"} string databaseId,
+                                           @display {label: "Old User ID"} string userId,
+                                           @display {label: "New User ID"} string newUserId) returns
                                            @tainted User|Error {
         http:Request request = new;
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_USER, userId]);
@@ -569,18 +570,18 @@ public client class ManagementClient {
     }
 
     # Get information of a user.
-    # 
+    #
     # + databaseId - ID of the database to which, the user belongs to
     # + userId - ID of user
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to the request
     # + return - If successful, returns a `User`. Else returns `Error`.
-    @display {label: "Get user"} 
-    remote isolated function getUser(@display {label: "Database Name"} string databaseId, 
-                                     @display {label: "User ID"} string userId, 
-                                     @display {label: "Optional Header Parameters"} ResourceReadOptions? 
+    @display {label: "Get User"}
+    remote isolated function getUser(@display {label: "Database ID"} string databaseId,
+                                     @display {label: "User ID"} string userId,
+                                     @display {label: "Optional Header Parameters"} ResourceReadOptions?
                                      resourceReadOptions = ()) returns @tainted User|Error {
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_USER, userId]);
-        map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET, 
+        map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET,
             requestPath);
         headerMap = setOptionalGetHeaders(headerMap, resourceReadOptions);
 
@@ -590,38 +591,38 @@ public client class ManagementClient {
     }
 
     # List users of a specific database.
-    # 
+    #
     # + databaseId - ID of the database to which, the user belongs to
-    # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to 
+    # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to
     #                         the request
-    # + return - If successful, returns a `stream<Data, error>`. Else returns `Error`.
-    @display {label: "Get users"} 
-    remote isolated function listUsers(@display {label: "Database Name"} string databaseId, 
-                                       @display {label: "Optional Header Parameters"} ResourceReadOptions? 
-                                       resourceReadOptions = ()) returns @tainted @display {label: "Stream of Users"} 
-                                       stream<Data, error>|Error { 
+    # + return - If successful, returns a `stream<User, error>`. Else returns `Error`.
+    @display {label: "Get Users"}
+    remote isolated function listUsers(@display {label: "Database ID"} string databaseId,
+                                       @display {label: "Optional Header Parameters"} ResourceReadOptions?
+                                       resourceReadOptions = ()) returns @tainted @display {label: "Stream of Users"}
+                                       stream<User, error>|Error {
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_USER]);
 
-        map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET, 
+        map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET,
             requestPath);
         headerMap = setOptionalGetHeaders(headerMap, resourceReadOptions);
 
-        RecordStream objectInstance = check new (self.httpClient, requestPath, headerMap);
-        stream<Data, error> finalStream = new (objectInstance);
+        UserStream objectInstance = check new (self.httpClient, requestPath, headerMap);
+        stream<User, error> finalStream = new (objectInstance);
         return finalStream;
     }
 
     # Delete a user.
-    # 
+    #
     # + databaseId - ID of the database to which, the user belongs to
     # + userId - ID of the user to delete
-    # + resourceDeleteOptions - The `ResourceDeleteOptions` which can be used to add additional 
+    # + resourceDeleteOptions - The `ResourceDeleteOptions` which can be used to add additional
     #                           capabilities to the request
     # + return - If successful, returns `DeleteResponse`. Else returns `Error`.
-    @display {label: "Delete user"} 
-    remote isolated function deleteUser(@display {label: "Database Name"} string databaseId, 
-                                        @display {label: "User ID"} string userId, 
-                                        @display {label: "Optional Header Parameters"} ResourceDeleteOptions? 
+    @display {label: "Delete User"}
+    remote isolated function deleteUser(@display {label: "Database ID"} string databaseId,
+                                        @display {label: "User ID"} string userId,
+                                        @display {label: "Optional Header Parameters"} ResourceDeleteOptions?
                                         resourceDeleteOptions = ()) returns @tainted DeleteResponse|Error {
         http:Request request = new;
         string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_USER, userId]);
@@ -630,11 +631,11 @@ public client class ManagementClient {
 
         http:Response response = check self.httpClient->delete(requestPath, request);
         check handleHeaderOnlyResponse(response);
-        return mapHeadersToResultType(response); 
+        return mapHeadersToResultType(response);
     }
 
-    # Create a permission for a user. 
-    # 
+    # Create a permission for a user.
+    #
     # + databaseId - ID of the database to which, the user belongs to
     # + userId - ID of user to which, the permission is granted. Must be a unique value.
     # + permissionId - A unique ID for the newly created permission
@@ -642,16 +643,16 @@ public client class ManagementClient {
     # + resourcePath - The resource this permission is allowing the user to access
     # + validityPeriodInSeconds - Optional. Validity period of the permission in seconds.
     # + return - If successful, returns a `Permission`. Else returns `Error`.
-    @display {label: "Create permission"} 
-    remote isolated function createPermission(@display {label: "Database Name"} string databaseId, 
-                                              @display {label: "User ID"} string userId, 
-                                              @display {label: "Permission ID"} string permissionId, 
-                                              @display {label: "Permission Mode"} PermisssionMode permissionMode, 
-                                              @display {label: "Resource Path"} string resourcePath, 
-                                              @display {label: "Validity Period in Seconds (optional)"} int? 
+    @display {label: "Create Permission"}
+    remote isolated function createPermission(@display {label: "Database ID"} string databaseId,
+                                              @display {label: "User ID"} string userId,
+                                              @display {label: "Permission ID"} string permissionId,
+                                              @display {label: "Permission Mode"} PermisssionMode permissionMode,
+                                              @display {label: "Resource Path"} string resourcePath,
+                                              @display {label: "Validity Period in Seconds (optional)"} int?
                                               validityPeriodInSeconds = ()) returns @tainted Permission|Error {
         http:Request request = new;
-        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_USER, userId, 
+        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_USER, userId,
             RESOURCE_TYPE_PERMISSION]);
         check setMandatoryHeaders(request, self.host, self.primaryKeyOrResourceToken, http:HTTP_POST, requestPath);
         if (validityPeriodInSeconds is int) {
@@ -671,7 +672,7 @@ public client class ManagementClient {
     }
 
     # Replace an existing permission.
-    # 
+    #
     # + databaseId - ID of the database where the user is created
     # + userId - ID of user to which, the permission is granted
     # + permissionId - The ID of the permission to be replaced
@@ -679,16 +680,16 @@ public client class ManagementClient {
     # + resourcePath - The resource this permission is allowing the user to access
     # + validityPeriodInSeconds - Optional. Validity period of the permission in seconds.
     # + return - If successful, returns a `Permission`. Else returns `Error`.
-    @display {label: "Replace permission"} 
-    remote isolated function replacePermission(@display {label: "Database Name"} string databaseId, 
-                                               @display {label: "User ID"} string userId, 
-                                               @display {label: "Permission ID"} string permissionId, 
-                                               @display {label: "Permission Mode"} PermisssionMode permissionMode, 
-                                               @display {label: "Resource Path"} string resourcePath, 
-                                               @display {label: "Validity Period in Seconds (optional)"} int? 
-                                               validityPeriodInSeconds = ()) returns @tainted Permission|Error { 
+    @display {label: "Replace Permission"}
+    remote isolated function replacePermission(@display {label: "Database ID"} string databaseId,
+                                               @display {label: "User ID"} string userId,
+                                               @display {label: "Permission ID"} string permissionId,
+                                               @display {label: "Permission Mode"} PermisssionMode permissionMode,
+                                               @display {label: "Resource Path"} string resourcePath,
+                                               @display {label: "Validity Period in Seconds (optional)"} int?
+                                               validityPeriodInSeconds = ()) returns @tainted Permission|Error {
         http:Request request = new;
-        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_USER, userId, 
+        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_USER, userId,
             RESOURCE_TYPE_PERMISSION, permissionId]);
         check setMandatoryHeaders(request, self.host, self.primaryKeyOrResourceToken, http:HTTP_PUT, requestPath);
         if (validityPeriodInSeconds is int) {
@@ -704,26 +705,26 @@ public client class ManagementClient {
 
         http:Response response = check self.httpClient->put(requestPath, request);
         json jsonResponse = check handleResponse(response);
-        return mapJsonToPermissionType(jsonResponse); 
+        return mapJsonToPermissionType(jsonResponse);
     }
 
     # Get information of a permission.
-    # 
+    #
     # + databaseId - ID of the database where the user is created
     # + userId - ID of user to which, the permission is granted
     # + permissionId - ID of the permission
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to the request
     # + return - If successful, returns a `Permission`. Else returns `Error`.
-    @display {label: "Get permission"} 
-    remote isolated function getPermission(@display {label: "Database Name"} string databaseId, 
+    @display {label: "Get Permission"}
+    remote isolated function getPermission(@display {label: "Database ID"} string databaseId,
                                            @display {label: "User ID"} string userId,
-                                           @display {label: "Permission ID"} string permissionId, 
-                                           @display {label: "Optional Header Parameters"} ResourceReadOptions? 
-                                           resourceReadOptions = ()) returns @tainted Permission|Error { 
-        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_USER, userId, 
+                                           @display {label: "Permission ID"} string permissionId,
+                                           @display {label: "Optional Header Parameters"} ResourceReadOptions?
+                                           resourceReadOptions = ()) returns @tainted Permission|Error {
+        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_USER, userId,
             RESOURCE_TYPE_PERMISSION, permissionId]);
 
-        map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET, 
+        map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET,
             requestPath);
         headerMap = setOptionalGetHeaders(headerMap, resourceReadOptions);
 
@@ -733,61 +734,61 @@ public client class ManagementClient {
     }
 
     # List permissions belong to a user.
-    # 
+    #
     # + databaseId - ID of the database where the user is created
     # + userId - ID of user to which, the permissions are granted
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to the request
-    # + return - If successful, returns a `stream<Data, error>`. Else returns `Error`.
-    @display {label: "Get permissions"} 
-    remote isolated function listPermissions(@display {label: "Database Name"} string databaseId, 
-                                             @display {label: "User ID"} string userId, 
-                                             @display {label: "Optional Header Parameters"} ResourceReadOptions? 
-                                             resourceReadOptions = ()) returns 
-                                             @tainted @display {label: "Stream of Permissions"} 
-                                             stream<Data, error>|Error { 
-        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_USER, userId, 
+    # + return - If successful, returns a `stream<Permission, error>`. Else returns `Error`.
+    @display {label: "Get Permissions"}
+    remote isolated function listPermissions(@display {label: "Database ID"} string databaseId,
+                                             @display {label: "User ID"} string userId,
+                                             @display {label: "Optional Header Parameters"} ResourceReadOptions?
+                                             resourceReadOptions = ()) returns
+                                             @tainted @display {label: "Stream of Permissions"}
+                                             stream<Permission, error>|Error {
+        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_USER, userId,
             RESOURCE_TYPE_PERMISSION]);
 
-        map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET, 
+        map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET,
             requestPath);
         headerMap = setOptionalGetHeaders(headerMap, resourceReadOptions);
-        
-        RecordStream objectInstance = check new (self.httpClient, requestPath, headerMap);
-        stream<Data, error> finalStream = new (objectInstance);
+
+        PermissionStream objectInstance = check new (self.httpClient, requestPath, headerMap);
+        stream<Permission, error> finalStream = new (objectInstance);
         return finalStream;
     }
 
     # Deletes a permission belongs to a user.
-    # 
+    #
     # + databaseId - ID of the database where the user is created
     # + userId - ID of user to which, the permission is granted
     # + permissionId - ID of the permission to delete
-    # + resourceDeleteOptions - The `ResourceDeleteOptions` which can be used to add additional capabilities to the 
+    # + resourceDeleteOptions - The `ResourceDeleteOptions` which can be used to add additional capabilities to the
     #                           request
     # + return - If successful, returns `DeleteResponse`. Else returns `Error`.
-    @display {label: "Delete permission"} 
-    remote isolated function deletePermission(@display {label: "Database Name"} string databaseId, 
-                                              @display {label: "User ID"} string userId, 
-                                              @display {label: "Permission ID"} string permissionId, 
-                                              @display {label: " Optional Header Parameters"} ResourceDeleteOptions? 
-                                              resourceDeleteOptions = ()) returns @tainted DeleteResponse|Error { 
+    @display {label: "Delete Permission"}
+    remote isolated function deletePermission(@display {label: "Database ID"} string databaseId,
+                                              @display {label: "User ID"} string userId,
+                                              @display {label: "Permission ID"} string permissionId,
+                                              @display {label: " Optional Header Parameters"} ResourceDeleteOptions?
+                                              resourceDeleteOptions = ()) returns @tainted DeleteResponse|Error {
         http:Request request = new;
-        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_USER, userId, 
+        string requestPath = prepareUrl([RESOURCE_TYPE_DATABASES, databaseId, RESOURCE_TYPE_USER, userId,
             RESOURCE_TYPE_PERMISSION, permissionId]);
         check setMandatoryHeaders(request, self.host, self.primaryKeyOrResourceToken, http:HTTP_DELETE, requestPath);
         setOptionalHeaders(request, resourceDeleteOptions);
 
         http:Response response = check self.httpClient->delete(requestPath, request);
-        json|error value = handleResponse(response); 
+        json|error value = handleResponse(response);
         check handleHeaderOnlyResponse(response);
-        return mapHeadersToResultType(response); 
+        return mapHeadersToResultType(response);
     }
 
     # Replace an existing offer.
-    # 
+    #
     # + offer - A record of type `Offer`
     # + return - If successful, returns a `Offer`. Else returns `Error`.
-    @display {label: "Replace offer"} 
+    @display {label: "Replace Offer"}
     remote isolated function replaceOffer(@display {label: "Offer ID"} Offer offer) returns @tainted Offer|Error {
         http:Request request = new;
         string requestPath = prepareUrl([RESOURCE_TYPE_OFFERS, offer.id]);
@@ -806,20 +807,20 @@ public client class ManagementClient {
 
         http:Response response = check self.httpClient->put(requestPath, request);
         json jsonResponse = check handleResponse(response);
-        return mapJsonToOfferType(jsonResponse); 
+        return mapJsonToOfferType(jsonResponse);
     }
 
     # Get information about an offer.
-    # 
+    #
     # + offerId - The ID of the offer
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to the request
     # + return - If successful, returns a `Offer`. Else returns `Error`.
-    @display {label: "Get offer"} 
-    remote isolated function getOffer(@display {label: "Offer ID"} string offerId, 
-                                      @display {label: "Optional Header Parameters"} ResourceReadOptions? 
+    @display {label: "Get Offer"}
+    remote isolated function getOffer(@display {label: "Offer ID"} string offerId,
+                                      @display {label: "Optional Header Parameters"} ResourceReadOptions?
                                       resourceReadOptions = ()) returns @tainted Offer|Error {
         string requestPath = prepareUrl([RESOURCE_TYPE_OFFERS, offerId]);
-        map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET, 
+        map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET,
             requestPath);
         headerMap = setOptionalGetHeaders(headerMap, resourceReadOptions);
 
@@ -828,39 +829,39 @@ public client class ManagementClient {
         return mapJsonToOfferType(jsonResponse);
     }
 
-    # List information of offers. Each Azure Cosmos DB collection is provisioned with an associated performance level 
+    # List information of offers. Each Azure Cosmos DB collection is provisioned with an associated performance level
     # represented as an offer resource in the REST model. Azure Cosmos DB supports offers representing both user-defined
-    # performance levels and pre-defined performance levels. 
-    # 
+    # performance levels and pre-defined performance levels.
+    #
     # + resourceReadOptions - The `ResourceReadOptions` which can be used to add additional capabilities to the request
-    # + return - If successful, returns a `stream<Data, error>` Else returns `Error`.
-    @display {label: "Get offers"} 
-    remote isolated function listOffers(@display {label: " Optional Header Parameters"} ResourceReadOptions? 
-                                        resourceReadOptions = ()) returns @tainted @display {label: "Stream of Offers"} 
-                                        stream<Data, error>|Error { 
+    # + return - If successful, returns a `stream<Offer, error>` Else returns `Error`.
+    @display {label: "Get Offers"}
+    remote isolated function listOffers(@display {label: " Optional Header Parameters"} ResourceReadOptions?
+                                        resourceReadOptions = ()) returns @tainted @display {label: "Stream of Offers"}
+                                        stream<Offer, error>|Error {
         string requestPath = prepareUrl([RESOURCE_TYPE_OFFERS]);
 
-        map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET, 
+        map<string> headerMap = check setMandatoryGetHeaders(self.host, self.primaryKeyOrResourceToken, http:HTTP_GET,
             requestPath);
         headerMap = setOptionalGetHeaders(headerMap, resourceReadOptions);
 
-        RecordStream objectInstance = check new (self.httpClient, requestPath, headerMap);
-        stream<Data, error> finalStream = new (objectInstance);
+        OfferStream objectInstance = check new (self.httpClient, requestPath, headerMap);
+        stream<Offer, error> finalStream = new (objectInstance);
         return finalStream;
     }
 
     # Perform queries on offer resources.
-    # 
+    #
     # + sqlQuery - A string value containing SQL query
-    # + resourceQueryOptions - The `ResourceQueryOptions` which can be used to add additional capabilities to the 
+    # + resourceQueryOptions - The `ResourceQueryOptions` which can be used to add additional capabilities to the
     #                          request
-    # + return - If successful, returns a `stream<QueryResult, error>`. Else returns `Error`.
-    @display {label: "Query offers"} 
-    remote isolated function queryOffer(@display {label: "SQL Query"} string sqlQuery, 
-                                        @display {label: "Optional Header Parameters"} ResourceQueryOptions? 
-                                        resourceQueryOptions = ()) returns 
-                                        @tainted @display {label: "Stream of Query Results"} 
-                                        stream<QueryResult, error>|Error { 
+    # + return - If successful, returns a `stream<Offer, error>`. Else returns `Error`.
+    @display {label: "Query Offers"}
+    remote isolated function queryOffer(@display {label: "SQL Query"} string sqlQuery,
+                                        @display {label: "Optional Header Parameters"} ResourceQueryOptions?
+                                        resourceQueryOptions = ()) returns
+                                        @tainted @display {label: "Stream of Query Results"}
+                                        stream<Offer, error>|Error {
         http:Request request = new;
         string requestPath = prepareUrl([RESOURCE_TYPE_OFFERS]);
         check setMandatoryHeaders(request, self.host, self.primaryKeyOrResourceToken, http:HTTP_POST, requestPath);
@@ -869,8 +870,8 @@ public client class ManagementClient {
         request.setJsonPayload({query: sqlQuery});
         check setHeadersForQuery(request);
 
-        QueryResultStream objectInstance = check new (self.httpClient, requestPath, request);
-        stream<QueryResult, error> finalStream = new (objectInstance);
+        OfferQueryResultStream objectInstance = check new (self.httpClient, requestPath, request);
+        stream<Offer, error> finalStream = new (objectInstance);
         return finalStream;
     }
 }

--- a/cosmosdb/samples/admin-operations/container/container_operations.bal
+++ b/cosmosdb/samples/admin-operations/container/container_operations.bal
@@ -151,10 +151,10 @@ public function main() {
     }
 
     log:printInfo("Getting list of containers");
-    stream<cosmosdb:Data,error>|error containerList = managementClient->listContainers(databaseId);
+    stream<cosmosdb:Container,error>|error containerList = managementClient->listContainers(databaseId);
 
-    if (containerList is stream<cosmosdb:Data,error>) {
-        error? e = containerList.forEach(function (cosmosdb:Data container) {
+    if (containerList is stream<cosmosdb:Container,error>) {
+        error? e = containerList.forEach(function (cosmosdb:Container container) {
             log:printInfo(container.toString());
         });
     } else {

--- a/cosmosdb/samples/admin-operations/container/list_containers.bal
+++ b/cosmosdb/samples/admin-operations/container/list_containers.bal
@@ -29,10 +29,10 @@ public function main() {
     string databaseId = "my_database";
 
     log:printInfo("Getting list of containers");   
-    stream<cosmosdb:Data, error>|error result = managementClient->listContainers(databaseId);
+    stream<cosmosdb:Container, error>|error result = managementClient->listContainers(databaseId);
 
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data container) {
+    if (result is stream<cosmosdb:Container, error>) {
+        error? e = result.forEach(function (cosmosdb:Container container) {
             log:printInfo(container.toString());
         });
         log:printInfo("Success!");

--- a/cosmosdb/samples/admin-operations/database/database_operations.bal
+++ b/cosmosdb/samples/admin-operations/database/database_operations.bal
@@ -102,10 +102,10 @@ public function main() {
     }
 
     log:printInfo("Getting list of databases");
-    stream<cosmosdb:Data,error>|error databaseList = managementClient->listDatabases();
+    stream<cosmosdb:Database,error>|error databaseList = managementClient->listDatabases();
 
-    if (databaseList is stream<cosmosdb:Data,error>) {
-        error? e = databaseList.forEach(function (cosmosdb:Data database) {
+    if (databaseList is stream<cosmosdb:Database,error>) {
+        error? e = databaseList.forEach(function (cosmosdb:Database database) {
             log:printInfo(database.toString());
         });
     } else {

--- a/cosmosdb/samples/admin-operations/database/list_databases.bal
+++ b/cosmosdb/samples/admin-operations/database/list_databases.bal
@@ -27,10 +27,10 @@ cosmosdb:ManagementClient managementClient = check new (config);
 
 public function main() {
     log:printInfo("Getting list of databases");
-    stream<cosmosdb:Data, error>|error result = managementClient->listDatabases();
+    stream<cosmosdb:Database, error>|error result = managementClient->listDatabases();
 
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data database) {
+    if (result is stream<cosmosdb:Database, error>) {
+        error? e = result.forEach(function (cosmosdb:Database database) {
             log:printInfo(database.toString());
         });
         log:printInfo("Success!");

--- a/cosmosdb/samples/admin-operations/offers/offer_operations.bal
+++ b/cosmosdb/samples/admin-operations/offers/offer_operations.bal
@@ -39,11 +39,11 @@ public function main() {
     cosmosdb:Container container = checkpanic managementClient->getContainer(databaseId, containerId);
 
     log:printInfo("List the offers in the current cosmos db account");   
-    stream<cosmosdb:Data, error>|error offerList = checkpanic managementClient->listOffers();
+    stream<cosmosdb:Offer, error>|error offerList = checkpanic managementClient->listOffers();
 
-    if (offerList is stream<cosmosdb:Data, error>) {
-        record {|cosmosdb:Data value;|}|error? offer = offerList.next();
-        if (offer is record {|cosmosdb:Data value;|}) {
+    if (offerList is stream<cosmosdb:Offer, error>) {
+        record {|cosmosdb:Offer value;|}|error? offer = offerList.next();
+        if (offer is record {|cosmosdb:Offer value;|}) {
             offerId = <@untainted>offer.value.id;
             resourceId = offer?.value?.resourceId;
         }

--- a/cosmosdb/samples/admin-operations/triggers/list_trigger.bal
+++ b/cosmosdb/samples/admin-operations/triggers/list_trigger.bal
@@ -30,10 +30,10 @@ public function main() {
     string containerId = "my_container";
 
     log:printInfo("List available triggers");
-    stream<cosmosdb:Data, error>|error result = managementClient->listTriggers(databaseId, containerId);
+    stream<cosmosdb:Trigger, error>|error result = managementClient->listTriggers(databaseId, containerId);
 
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data trigger) {
+    if (result is stream<cosmosdb:Trigger, error>) {
+        error? e = result.forEach(function (cosmosdb:Trigger trigger) {
             log:printInfo(trigger.toString());
         });
         log:printInfo("Success!");

--- a/cosmosdb/samples/admin-operations/triggers/trigger_operations.bal
+++ b/cosmosdb/samples/admin-operations/triggers/trigger_operations.bal
@@ -114,10 +114,10 @@ public function main() {
     }
 
     log:printInfo("List available triggers");
-    stream<cosmosdb:Data, error>|error triggerList = managementClient->listTriggers(databaseId, containerId);
+    stream<cosmosdb:Trigger, error>|error triggerList = managementClient->listTriggers(databaseId, containerId);
 
-    if (triggerList is stream<cosmosdb:Data, error>) {
-        error? e = triggerList.forEach(function (cosmosdb:Data trigger) {
+    if (triggerList is stream<cosmosdb:Trigger, error>) {
+        error? e = triggerList.forEach(function (cosmosdb:Trigger trigger) {
             log:printInfo(trigger.toString());
         });
         log:printInfo("Success!");

--- a/cosmosdb/samples/admin-operations/user-defined-functions/list_udf.bal
+++ b/cosmosdb/samples/admin-operations/user-defined-functions/list_udf.bal
@@ -30,10 +30,10 @@ public function main() {
     string containerId = "my_container";
 
     log:printInfo("List  user defined functions");
-    stream<cosmosdb:Data, error>|error result = managementClient->listUserDefinedFunctions(databaseId, containerId);
+    stream<cosmosdb:UserDefinedFunction, error>|error result = managementClient->listUserDefinedFunctions(databaseId, containerId);
 
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data udf) {
+    if (result is stream<cosmosdb:UserDefinedFunction, error>) {
+        error? e = result.forEach(function (cosmosdb:UserDefinedFunction udf) {
             log:printInfo(udf.toString());
         });
         log:printInfo("Success!");

--- a/cosmosdb/samples/admin-operations/user-defined-functions/user_defined_functions.bal
+++ b/cosmosdb/samples/admin-operations/user-defined-functions/user_defined_functions.bal
@@ -79,9 +79,9 @@ public function main() {
     }
 
     log:printInfo("List  user defined functions(udf)s");
-    stream<cosmosdb:Data, error>|error udfList = managementClient->listUserDefinedFunctions(databaseId, containerId);
-    if (udfList is stream<cosmosdb:Data, error>) {
-        error? e = udfList.forEach(function (cosmosdb:Data udf) {
+    stream<cosmosdb:UserDefinedFunction, error>|error udfList = managementClient->listUserDefinedFunctions(databaseId, containerId);
+    if (udfList is stream<cosmosdb:UserDefinedFunction, error>) {
+        error? e = udfList.forEach(function (cosmosdb:UserDefinedFunction udf) {
             log:printInfo(udf.toString());
         });
         log:printInfo("Success!");
@@ -90,7 +90,7 @@ public function main() {
     }
 
     log:printInfo("Delete user defined function");
-    cosmosdb:DeleteResponse|error deletionResult = managementClient->deleteUserDefinedFunction(databaseId, containerId, 
+    cosmosdb:DeleteResponse|error deletionResult = managementClient->deleteUserDefinedFunction(databaseId, containerId,
         udfId);
 
     if (deletionResult is cosmosdb:DeleteResponse) {

--- a/cosmosdb/samples/admin-operations/users-permissions/permission/list_permissions.bal
+++ b/cosmosdb/samples/admin-operations/users-permissions/permission/list_permissions.bal
@@ -30,10 +30,10 @@ public function main() {
     string userId = "my_user";
 
     log:printInfo("List permissions");
-    stream<cosmosdb:Data, error>|error result = managementClient->listPermissions(databaseId, userId);
+    stream<cosmosdb:Permission, error>|error result = managementClient->listPermissions(databaseId, userId);
 
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data storedPrcedure) {
+    if (result is stream<cosmosdb:Permission, error>) {
+        error? e = result.forEach(function (cosmosdb:Permission storedPrcedure) {
             log:printInfo(storedPrcedure.toString());
         });
         log:printInfo("Success!");

--- a/cosmosdb/samples/admin-operations/users-permissions/user/list_users.bal
+++ b/cosmosdb/samples/admin-operations/users-permissions/user/list_users.bal
@@ -29,9 +29,9 @@ public function main() {
     string databaseId = "my_database";
 
     log:printInfo("List users");
-    stream<cosmosdb:Data, error>|error result = managementClient->listUsers(databaseId);
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data storedPrcedure) {
+    stream<cosmosdb:User, error>|error result = managementClient->listUsers(databaseId);
+    if (result is stream<cosmosdb:User, error>) {
+        error? e = result.forEach(function (cosmosdb:User storedPrcedure) {
             log:printInfo(storedPrcedure.toString());
         });
         log:printInfo("Success!");

--- a/cosmosdb/samples/admin-operations/users-permissions/users_access_control.bal
+++ b/cosmosdb/samples/admin-operations/users-permissions/users_access_control.bal
@@ -69,9 +69,9 @@ public function main() {
     }
 
     log:printInfo("List users");
-    stream<cosmosdb:Data, error>|error userList = managementClient->listUsers(databaseId);
-    if (userList is stream<cosmosdb:Data, error>) {
-        error? e = userList.forEach(function (cosmosdb:Data storedPrcedure) {
+    stream<cosmosdb:User, error>|error userList = managementClient->listUsers(databaseId);
+    if (userList is stream<cosmosdb:User, error>) {
+        error? e = userList.forEach(function (cosmosdb:User storedPrcedure) {
             log:printInfo(storedPrcedure.toString());
         });
         log:printInfo("Success!");
@@ -84,10 +84,10 @@ public function main() {
     log:printInfo("Create permission for a user");
     string permissionId = string `permission_${uuid.toString()}`;
     cosmosdb:PermisssionMode permissionMode = "All";
-    string permissionResource = 
+    string permissionResource =
         string `dbs/${database?.resourceId.toString()}/colls/${container?.resourceId.toString()}`;
-        
-    cosmosdb:Permission|error permission = managementClient->createPermission(databaseId, userId, permissionId, 
+
+    cosmosdb:Permission|error permission = managementClient->createPermission(databaseId, userId, permissionId,
         permissionMode, <@untainted>permissionResource);
 
     if (permission is cosmosdb:Permission) {
@@ -98,7 +98,7 @@ public function main() {
     }
 
     // Create permission with time to live
-    // 
+    //
     // string newPermissionMode = "Read";
     // string newPermissionResource = string `dbs/${database?.resourceId.toString()}/colls/${container?.resourceId.
     // toString()}`;
@@ -119,7 +119,7 @@ public function main() {
     cosmosdb:PermisssionMode permissionModeReplace = "All";
     string permissionResourceReplace = string `dbs/${databaseId}/colls/${containerId}`;
 
-    permission = managementClient->replacePermission(databaseId, userId, permissionId, 
+    permission = managementClient->replacePermission(databaseId, userId, permissionId,
         permissionModeReplace, permissionResourceReplace);
 
     if (permission is cosmosdb:Permission) {
@@ -130,9 +130,9 @@ public function main() {
     }
 
     log:printInfo("List permissions");
-    stream<cosmosdb:Data, error>|error permissionList = managementClient->listPermissions(databaseId, userId);
-    if (permissionList is stream<cosmosdb:Data, error>) {
-        error? e = permissionList.forEach(function (cosmosdb:Data storedPrcedure) {
+    stream<cosmosdb:Permission, error>|error permissionList = managementClient->listPermissions(databaseId, userId);
+    if (permissionList is stream<cosmosdb:Permission, error>) {
+        error? e = permissionList.forEach(function (cosmosdb:Permission storedPrcedure) {
             log:printInfo(storedPrcedure.toString());
         });
         log:printInfo("Success!");

--- a/cosmosdb/samples/data-operations/documents/document_operations.bal
+++ b/cosmosdb/samples/data-operations/documents/document_operations.bal
@@ -173,10 +173,10 @@ public function main() {
     }
 
     log:printInfo("Getting list of documents");
-    stream<cosmosdb:Data, error>|error documentList = azureCosmosClient->getDocumentList(databaseId, containerId);
+    stream<cosmosdb:Document, error>|error documentList = azureCosmosClient->getDocumentList(databaseId, containerId);
 
-    if (documentList is stream<cosmosdb:Data, error>) {
-        error? e = documentList.forEach(function (cosmosdb:Data document) {
+    if (documentList is stream<cosmosdb:Document, error>) {
+        error? e = documentList.forEach(function (cosmosdb:Document document) {
             log:printInfo(document.toString());
         });
         log:printInfo("Success!");
@@ -185,7 +185,7 @@ public function main() {
     }
 
     log:printInfo("Deleting the document");
-    cosmosdb:DeleteResponse|error deletionResult = azureCosmosClient->deleteDocument(databaseId, containerId, 
+    cosmosdb:DeleteResponse|error deletionResult = azureCosmosClient->deleteDocument(databaseId, containerId,
         documentId, partitionKeyValue);
 
     if (deletionResult is cosmosdb:DeleteResponse) {
@@ -213,7 +213,7 @@ function closeRc(io:ReadableCharacterChannel rc) {
 }
 
 # Create a random UUID removing the unnecessary hyphens which will interrupt querying opearations.
-# 
+#
 # + return - A string UUID without hyphens
 function createRandomUUIDWithoutHyphens() returns string {
     string? stringUUID = java:toString(createRandomUUID());

--- a/cosmosdb/samples/data-operations/documents/list_documents.bal
+++ b/cosmosdb/samples/data-operations/documents/list_documents.bal
@@ -30,10 +30,10 @@ public function main() {
     string containerId = "my_container";
 
     log:printInfo("Getting list of documents");
-    stream<cosmosdb:Data, error>|error result = azureCosmosClient->getDocumentList(databaseId, containerId);
+    stream<cosmosdb:Document, error>|error result = azureCosmosClient->getDocumentList(databaseId, containerId);
 
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data document) {
+    if (result is stream<cosmosdb:Document, error>) {
+        error? e = result.forEach(function (cosmosdb:Document document) {
             log:printInfo(document.toString());
         });
         log:printInfo("Success!");

--- a/cosmosdb/samples/data-operations/documents/query_document.bal
+++ b/cosmosdb/samples/data-operations/documents/query_document.bal
@@ -33,11 +33,11 @@ public function main() {
     string selectAllQuery = string `SELECT * FROM ${containerId.toString()} f WHERE f.gender = ${0}`;
 
     cosmosdb:ResourceQueryOptions options = {partitionKey : 0, enableCrossPartition: false};
-    stream<cosmosdb:QueryResult, error>|error result = azureCosmosClient->queryDocuments(databaseId, containerId, 
+    stream<cosmosdb:Document, error>|error result = azureCosmosClient->queryDocuments(databaseId, containerId,
         selectAllQuery, options);
 
-    if (result is stream<cosmosdb:QueryResult, error>) {
-        error? e = result.forEach(function (cosmosdb:QueryResult queryResult) {
+    if (result is stream<cosmosdb:Document, error>) {
+        error? e = result.forEach(function (cosmosdb:Document queryResult) {
             log:printInfo(queryResult.toString());
         });
         log:printInfo("Success!");

--- a/cosmosdb/samples/data-operations/stored-procedure/list_stored_procedure.bal
+++ b/cosmosdb/samples/data-operations/stored-procedure/list_stored_procedure.bal
@@ -30,9 +30,9 @@ public function main() {
     string containerId = "my_container";
 
     log:printInfo("List stored procedure");
-    stream<cosmosdb:Data, error>|error result = azureCosmosClient->listStoredProcedures(databaseId, containerId);
-    if (result is stream<cosmosdb:Data, error>) {
-        error? e = result.forEach(function (cosmosdb:Data storedPrcedure) {
+    stream<cosmosdb:StoredProcedure, error>|error result = azureCosmosClient->listStoredProcedures(databaseId, containerId);
+    if (result is stream<cosmosdb:StoredProcedure, error>) {
+        error? e = result.forEach(function (cosmosdb:StoredProcedure storedPrcedure) {
             log:printInfo(storedPrcedure.toString());
         });
         log:printInfo("Success!");

--- a/cosmosdb/samples/data-operations/stored-procedure/stored_procedure_operations.bal
+++ b/cosmosdb/samples/data-operations/stored-procedure/stored_procedure_operations.bal
@@ -66,9 +66,9 @@ public function main() {
     }
 
     log:printInfo("List stored procedures");
-    stream<cosmosdb:Data, error>|error spList = azureCosmosClient->listStoredProcedures(databaseId, containerId);
-    if (spList is stream<cosmosdb:Data, error>) {
-        error? e = spList.forEach(function (cosmosdb:Data storedPrcedure) {
+    stream<cosmosdb:StoredProcedure, error>|error spList = azureCosmosClient->listStoredProcedures(databaseId, containerId);
+    if (spList is stream<cosmosdb:StoredProcedure, error>) {
+        error? e = spList.forEach(function (cosmosdb:StoredProcedure storedPrcedure) {
             log:printInfo(storedPrcedure.toString());
         });
         log:printInfo("Success!");
@@ -81,7 +81,7 @@ public function main() {
         parameters: ["Sachi"]
     };
 
-    json|error result = azureCosmosClient->executeStoredProcedure(databaseId, containerId, storedProcedureId, options); 
+    json|error result = azureCosmosClient->executeStoredProcedure(databaseId, containerId, storedProcedureId, options);
 
     if (result is json) {
         log:printInfo(result.toString());
@@ -90,7 +90,7 @@ public function main() {
     }
 
     log:printInfo("Deleting stored procedure");
-    cosmosdb:DeleteResponse|error deletionResult = azureCosmosClient->deleteStoredProcedure(databaseId, containerId, 
+    cosmosdb:DeleteResponse|error deletionResult = azureCosmosClient->deleteStoredProcedure(databaseId, containerId,
         storedProcedureId);
 
     if (deletionResult is cosmosdb:DeleteResponse) {

--- a/cosmosdb/stream_implementer.bal
+++ b/cosmosdb/stream_implementer.bal
@@ -16,9 +16,9 @@
 
 import ballerina/http;
 
-// This stream implmenter works for GET requests
-class RecordStream {
-    private Data[] currentEntries = [];
+// This stream implementer works for GET requests
+class DatabaseStream {
+    private Database[] currentEntries = [];
     private string continuationToken;
     int index = 0;
     private final http:Client httpClient;
@@ -30,26 +30,26 @@ class RecordStream {
         self.path = path;
         self.continuationToken = EMPTY_STRING;
         self.headerMap = headerMap;
-        self.currentEntries = check self.fetchRecords();
+        self.currentEntries = check self.fetchDatabases();
     }
 
-    public isolated function next() returns @tainted record {| Data value; |}|error? {
+    public isolated function next() returns @tainted record {| Database value; |}|error? {
         if(self.index < self.currentEntries.length()) {
-            record {| Data value; |} singleRecord = {value: self.currentEntries[self.index]};
+            record {| Database value; |} singleRecord = {value: self.currentEntries[self.index]};
             self.index += 1;
             return singleRecord;
         }
         // This code block is for retrieving the next batch of records when the initial batch is finished.
         if (self.continuationToken != EMPTY_STRING) {
             self.index = 0;
-            self.currentEntries = check self.fetchRecords();
-            record {| Data value; |} singleRecord = {value: self.currentEntries[self.index]};
+            self.currentEntries = check self.fetchDatabases();
+            record {| Database value; |} singleRecord = {value: self.currentEntries[self.index]};
             self.index += 1;
             return singleRecord;
         }
     }
 
-    isolated function fetchRecords() returns @tainted Data[]|Error {
+    isolated function fetchDatabases() returns @tainted Database[]|Error {
         if (self.continuationToken != EMPTY_STRING) {
             self.headerMap[CONTINUATION_HEADER] = self.continuationToken;
         }
@@ -60,31 +60,452 @@ class RecordStream {
         if (payload.Databases is json) {
             json[] array = let var load = payload.Databases in load is json ? <json[]>load : [];
             return convertToDatabaseArray(array);
-        } else if (payload.DocumentCollections is json) {
+
+        } else {
+            return error PayloadValidationError(INVALID_RESPONSE_PAYLOAD_ERROR);
+        }
+    }
+}
+
+class ContainerStream {
+    private Container[] currentEntries = [];
+    private string continuationToken;
+    int index = 0;
+    private final http:Client httpClient;
+    private final string path;
+    private map<string> headerMap;
+
+    isolated function  init(http:Client httpClient, string path, map<string> headerMap) returns @tainted error? {
+        self.httpClient = httpClient;
+        self.path = path;
+        self.continuationToken = EMPTY_STRING;
+        self.headerMap = headerMap;
+        self.currentEntries = check self.fetchContainers();
+    }
+
+    public isolated function next() returns @tainted record {| Container value; |}|error? {
+        if(self.index < self.currentEntries.length()) {
+            record {| Container value; |} singleRecord = {value: self.currentEntries[self.index]};
+            self.index += 1;
+            return singleRecord;
+        }
+        // This code block is for retrieving the next batch of records when the initial batch is finished.
+        if (self.continuationToken != EMPTY_STRING) {
+            self.index = 0;
+            self.currentEntries = check self.fetchContainers();
+            record {| Container value; |} singleRecord = {value: self.currentEntries[self.index]};
+            self.index += 1;
+            return singleRecord;
+        }
+    }
+
+    isolated function fetchContainers() returns @tainted Container[]|Error {
+        if (self.continuationToken != EMPTY_STRING) {
+            self.headerMap[CONTINUATION_HEADER] = self.continuationToken;
+        }
+        http:Response response = check self.httpClient->get(self.path, self.headerMap);
+        self.continuationToken = let var header = response.getHeader(CONTINUATION_HEADER) in header is string ? header :
+            EMPTY_STRING;
+        json payload = check handleResponse(response);
+
+        if (payload.DocumentCollections is json) {
             json[] array = let var load = payload.DocumentCollections in load is json ? <json[]>load : [];
             return convertToContainerArray(array);
-        } else if (payload.Documents is json) {
+        } else {
+            return error PayloadValidationError(INVALID_RESPONSE_PAYLOAD_ERROR);
+        }
+    }
+}
+
+class DocumentStream {
+    private Document[] currentEntries = [];
+    private string continuationToken;
+    int index = 0;
+    private final http:Client httpClient;
+    private final string path;
+    private map<string> headerMap;
+
+    isolated function  init(http:Client httpClient, string path, map<string> headerMap) returns @tainted error? {
+        self.httpClient = httpClient;
+        self.path = path;
+        self.continuationToken = EMPTY_STRING;
+        self.headerMap = headerMap;
+        self.currentEntries = check self.fetchDocuments();
+    }
+
+    public isolated function next() returns @tainted record {| Document value; |}|error? {
+        if(self.index < self.currentEntries.length()) {
+            record {| Document value; |} singleRecord = {value: self.currentEntries[self.index]};
+            self.index += 1;
+            return singleRecord;
+        }
+        // This code block is for retrieving the next batch of records when the initial batch is finished.
+        if (self.continuationToken != EMPTY_STRING) {
+            self.index = 0;
+            self.currentEntries = check self.fetchDocuments();
+            record {| Document value; |} singleRecord = {value: self.currentEntries[self.index]};
+            self.index += 1;
+            return singleRecord;
+        }
+    }
+
+    isolated function fetchDocuments() returns @tainted Document[]|Error {
+        if (self.continuationToken != EMPTY_STRING) {
+            self.headerMap[CONTINUATION_HEADER] = self.continuationToken;
+        }
+        http:Response response = check self.httpClient->get(self.path, self.headerMap);
+        self.continuationToken = let var header = response.getHeader(CONTINUATION_HEADER) in header is string ? header :
+            EMPTY_STRING;
+        json payload = check handleResponse(response);
+        if (payload.Documents is json) {
             json[] array = let var load = payload.Documents in load is json ? <json[]>load : [];
             return convertToDocumentArray(array);
-        } else if (payload.StoredProcedures is json) {
+        } else {
+            return error PayloadValidationError(INVALID_RESPONSE_PAYLOAD_ERROR);
+        }
+    }
+}
+
+class StoredProcedureStream {
+    private StoredProcedure[] currentEntries = [];
+    private string continuationToken;
+    int index = 0;
+    private final http:Client httpClient;
+    private final string path;
+    private map<string> headerMap;
+
+    isolated function  init(http:Client httpClient, string path, map<string> headerMap) returns @tainted error? {
+        self.httpClient = httpClient;
+        self.path = path;
+        self.continuationToken = EMPTY_STRING;
+        self.headerMap = headerMap;
+        self.currentEntries = check self.fetchStoredProcedures();
+    }
+
+    public isolated function next() returns @tainted record {| StoredProcedure value; |}|error? {
+        if(self.index < self.currentEntries.length()) {
+            record {| StoredProcedure value; |} singleRecord = {value: self.currentEntries[self.index]};
+            self.index += 1;
+            return singleRecord;
+        }
+        // This code block is for retrieving the next batch of records when the initial batch is finished.
+        if (self.continuationToken != EMPTY_STRING) {
+            self.index = 0;
+            self.currentEntries = check self.fetchStoredProcedures();
+            record {| StoredProcedure value; |} singleRecord = {value: self.currentEntries[self.index]};
+            self.index += 1;
+            return singleRecord;
+        }
+    }
+
+    isolated function fetchStoredProcedures() returns @tainted StoredProcedure[]|Error {
+        if (self.continuationToken != EMPTY_STRING) {
+            self.headerMap[CONTINUATION_HEADER] = self.continuationToken;
+        }
+        http:Response response = check self.httpClient->get(self.path, self.headerMap);
+        self.continuationToken = let var header = response.getHeader(CONTINUATION_HEADER) in header is string ? header :
+            EMPTY_STRING;
+        json payload = check handleResponse(response);
+        if (payload.StoredProcedures is json) {
             json[] array = let var load = payload.StoredProcedures in load is json ? <json[]>load : [];
             return convertToStoredProcedureArray(array);
-        } else if (payload.UserDefinedFunctions is json) {
+        } else {
+            return error PayloadValidationError(INVALID_RESPONSE_PAYLOAD_ERROR);
+        }
+    }
+}
+
+class UserDefiinedFunctionStream {
+    private UserDefinedFunction[] currentEntries = [];
+    private string continuationToken;
+    int index = 0;
+    private final http:Client httpClient;
+    private final string path;
+    private map<string> headerMap;
+
+    isolated function  init(http:Client httpClient, string path, map<string> headerMap) returns @tainted error? {
+        self.httpClient = httpClient;
+        self.path = path;
+        self.continuationToken = EMPTY_STRING;
+        self.headerMap = headerMap;
+        self.currentEntries = check self.fetchUserDefinedFunctions();
+    }
+
+    public isolated function next() returns @tainted record {| UserDefinedFunction value; |}|error? {
+        if(self.index < self.currentEntries.length()) {
+            record {| UserDefinedFunction value; |} singleRecord = {value: self.currentEntries[self.index]};
+            self.index += 1;
+            return singleRecord;
+        }
+        // This code block is for retrieving the next batch of records when the initial batch is finished.
+        if (self.continuationToken != EMPTY_STRING) {
+            self.index = 0;
+            self.currentEntries = check self.fetchUserDefinedFunctions();
+            record {| UserDefinedFunction value; |} singleRecord = {value: self.currentEntries[self.index]};
+            self.index += 1;
+            return singleRecord;
+        }
+    }
+
+    isolated function fetchUserDefinedFunctions() returns @tainted UserDefinedFunction[]|Error {
+        if (self.continuationToken != EMPTY_STRING) {
+            self.headerMap[CONTINUATION_HEADER] = self.continuationToken;
+        }
+        http:Response response = check self.httpClient->get(self.path, self.headerMap);
+        self.continuationToken = let var header = response.getHeader(CONTINUATION_HEADER) in header is string ? header :
+            EMPTY_STRING;
+        json payload = check handleResponse(response);
+
+        if (payload.UserDefinedFunctions is json) {
             json[] array = let var load = payload.UserDefinedFunctions in load is json ? <json[]>load : [];
             return convertsToUserDefinedFunctionArray(array);
-        } else if (payload.Triggers is json) {
+        } else {
+            return error PayloadValidationError(INVALID_RESPONSE_PAYLOAD_ERROR);
+        }
+    }
+}
+
+class TriggerStream {
+    private Trigger[] currentEntries = [];
+    private string continuationToken;
+    int index = 0;
+    private final http:Client httpClient;
+    private final string path;
+    private map<string> headerMap;
+
+    isolated function  init(http:Client httpClient, string path, map<string> headerMap) returns @tainted error? {
+        self.httpClient = httpClient;
+        self.path = path;
+        self.continuationToken = EMPTY_STRING;
+        self.headerMap = headerMap;
+        self.currentEntries = check self.fetchTriggers();
+    }
+
+    public isolated function next() returns @tainted record {| Trigger value; |}|error? {
+        if(self.index < self.currentEntries.length()) {
+            record {| Trigger value; |} singleRecord = {value: self.currentEntries[self.index]};
+            self.index += 1;
+            return singleRecord;
+        }
+        // This code block is for retrieving the next batch of records when the initial batch is finished.
+        if (self.continuationToken != EMPTY_STRING) {
+            self.index = 0;
+            self.currentEntries = check self.fetchTriggers();
+            record {| Trigger value; |} singleRecord = {value: self.currentEntries[self.index]};
+            self.index += 1;
+            return singleRecord;
+        }
+    }
+
+    isolated function fetchTriggers() returns @tainted Trigger[]|Error {
+        if (self.continuationToken != EMPTY_STRING) {
+            self.headerMap[CONTINUATION_HEADER] = self.continuationToken;
+        }
+        http:Response response = check self.httpClient->get(self.path, self.headerMap);
+        self.continuationToken = let var header = response.getHeader(CONTINUATION_HEADER) in header is string ? header :
+            EMPTY_STRING;
+        json payload = check handleResponse(response);
+
+        if (payload.Triggers is json) {
             json[] array = let var load = payload.Triggers in load is json ? <json[]>load : [];
             return convertToTriggerArray(array);
-        } else if (payload.Users is json) {
+        } else {
+            return error PayloadValidationError(INVALID_RESPONSE_PAYLOAD_ERROR);
+        }
+    }
+}
+
+class UserStream {
+    private User[] currentEntries = [];
+    private string continuationToken;
+    int index = 0;
+    private final http:Client httpClient;
+    private final string path;
+    private map<string> headerMap;
+
+    isolated function  init(http:Client httpClient, string path, map<string> headerMap) returns @tainted error? {
+        self.httpClient = httpClient;
+        self.path = path;
+        self.continuationToken = EMPTY_STRING;
+        self.headerMap = headerMap;
+        self.currentEntries = check self.fetchUsers();
+    }
+
+    public isolated function next() returns @tainted record {| User value; |}|error? {
+        if(self.index < self.currentEntries.length()) {
+            record {| User value; |} singleRecord = {value: self.currentEntries[self.index]};
+            self.index += 1;
+            return singleRecord;
+        }
+        // This code block is for retrieving the next batch of records when the initial batch is finished.
+        if (self.continuationToken != EMPTY_STRING) {
+            self.index = 0;
+            self.currentEntries = check self.fetchUsers();
+            record {| User value; |} singleRecord = {value: self.currentEntries[self.index]};
+            self.index += 1;
+            return singleRecord;
+        }
+    }
+
+    isolated function fetchUsers() returns @tainted User[]|Error {
+        if (self.continuationToken != EMPTY_STRING) {
+            self.headerMap[CONTINUATION_HEADER] = self.continuationToken;
+        }
+        http:Response response = check self.httpClient->get(self.path, self.headerMap);
+        self.continuationToken = let var header = response.getHeader(CONTINUATION_HEADER) in header is string ? header :
+            EMPTY_STRING;
+        json payload = check handleResponse(response);
+
+        if (payload.Users is json) {
             json[] array = let var load = payload.Users in load is json ? <json[]>load : [];
             return convertToUserArray(array);
-        } else if (payload.Permissions is json) {
+        } else {
+            return error PayloadValidationError(INVALID_RESPONSE_PAYLOAD_ERROR);
+        }
+    }
+}
+
+
+class PermissionStream {
+    private Permission[] currentEntries = [];
+    private string continuationToken;
+    int index = 0;
+    private final http:Client httpClient;
+    private final string path;
+    private map<string> headerMap;
+
+    isolated function  init(http:Client httpClient, string path, map<string> headerMap) returns @tainted error? {
+        self.httpClient = httpClient;
+        self.path = path;
+        self.continuationToken = EMPTY_STRING;
+        self.headerMap = headerMap;
+        self.currentEntries = check self.fetchPermission();
+    }
+
+    public isolated function next() returns @tainted record {| Permission value; |}|error? {
+        if(self.index < self.currentEntries.length()) {
+            record {| Permission value; |} singleRecord = {value: self.currentEntries[self.index]};
+            self.index += 1;
+            return singleRecord;
+        }
+        // This code block is for retrieving the next batch of records when the initial batch is finished.
+        if (self.continuationToken != EMPTY_STRING) {
+            self.index = 0;
+            self.currentEntries = check self.fetchPermission();
+            record {| Permission value; |} singleRecord = {value: self.currentEntries[self.index]};
+            self.index += 1;
+            return singleRecord;
+        }
+    }
+
+    isolated function fetchPermission() returns @tainted Permission[]|Error {
+        if (self.continuationToken != EMPTY_STRING) {
+            self.headerMap[CONTINUATION_HEADER] = self.continuationToken;
+        }
+        http:Response response = check self.httpClient->get(self.path, self.headerMap);
+        self.continuationToken = let var header = response.getHeader(CONTINUATION_HEADER) in header is string ? header :
+            EMPTY_STRING;
+        json payload = check handleResponse(response);
+
+        if (payload.Permissions is json) {
             json[] array = let var load = payload.Permissions in load is json ? <json[]>load : [];
             return convertToPermissionArray(array);
-        } else if (payload.Offers is json) {
+        } else {
+            return error PayloadValidationError(INVALID_RESPONSE_PAYLOAD_ERROR);
+        }
+    }
+}
+
+class OfferStream {
+    private Offer[] currentEntries = [];
+    private string continuationToken;
+    int index = 0;
+    private final http:Client httpClient;
+    private final string path;
+    private map<string> headerMap;
+
+    isolated function  init(http:Client httpClient, string path, map<string> headerMap) returns @tainted error? {
+        self.httpClient = httpClient;
+        self.path = path;
+        self.continuationToken = EMPTY_STRING;
+        self.headerMap = headerMap;
+        self.currentEntries = check self.fetchOffers();
+    }
+
+    public isolated function next() returns @tainted record {| Offer value; |}|error? {
+        if(self.index < self.currentEntries.length()) {
+            record {| Offer value; |} singleRecord = {value: self.currentEntries[self.index]};
+            self.index += 1;
+            return singleRecord;
+        }
+        // This code block is for retrieving the next batch of records when the initial batch is finished.
+        if (self.continuationToken != EMPTY_STRING) {
+            self.index = 0;
+            self.currentEntries = check self.fetchOffers();
+            record {| Offer value; |} singleRecord = {value: self.currentEntries[self.index]};
+            self.index += 1;
+            return singleRecord;
+        }
+    }
+
+    isolated function fetchOffers() returns @tainted Offer[]|Error {
+        if (self.continuationToken != EMPTY_STRING) {
+            self.headerMap[CONTINUATION_HEADER] = self.continuationToken;
+        }
+        http:Response response = check self.httpClient->get(self.path, self.headerMap);
+        self.continuationToken = let var header = response.getHeader(CONTINUATION_HEADER) in header is string ? header :
+            EMPTY_STRING;
+        json payload = check handleResponse(response);
+        if (payload.Offers is json) {
             json[] array = let var load = payload.Offers in load is json ? <json[]>load : [];
             return convertToOfferArray(array);
-        } else if (payload.PartitionKeyRanges is json) {
+        } else {
+            return error PayloadValidationError(INVALID_RESPONSE_PAYLOAD_ERROR);
+        }
+    }
+}
+
+class PartitionKeyRangeStream {
+    private PartitionKeyRange[] currentEntries = [];
+    private string continuationToken;
+    int index = 0;
+    private final http:Client httpClient;
+    private final string path;
+    private map<string> headerMap;
+
+    isolated function  init(http:Client httpClient, string path, map<string> headerMap) returns @tainted error? {
+        self.httpClient = httpClient;
+        self.path = path;
+        self.continuationToken = EMPTY_STRING;
+        self.headerMap = headerMap;
+        self.currentEntries = check self.fetchPKRanges();
+    }
+
+    public isolated function next() returns @tainted record {| PartitionKeyRange value; |}|error? {
+        if(self.index < self.currentEntries.length()) {
+            record {| PartitionKeyRange value; |} singleRecord = {value: self.currentEntries[self.index]};
+            self.index += 1;
+            return singleRecord;
+        }
+        // This code block is for retrieving the next batch of records when the initial batch is finished.
+        if (self.continuationToken != EMPTY_STRING) {
+            self.index = 0;
+            self.currentEntries = check self.fetchPKRanges();
+            record {| PartitionKeyRange value; |} singleRecord = {value: self.currentEntries[self.index]};
+            self.index += 1;
+            return singleRecord;
+        }
+    }
+
+    isolated function fetchPKRanges() returns @tainted PartitionKeyRange[]|Error {
+        if (self.continuationToken != EMPTY_STRING) {
+            self.headerMap[CONTINUATION_HEADER] = self.continuationToken;
+        }
+        http:Response response = check self.httpClient->get(self.path, self.headerMap);
+        self.continuationToken = let var header = response.getHeader(CONTINUATION_HEADER) in header is string ? header :
+            EMPTY_STRING;
+        json payload = check handleResponse(response);
+        if (payload.PartitionKeyRanges is json) {
             json[] array = let var load = payload.PartitionKeyRanges in load is json ? <json[]>load : [];
             return convertToPartitionKeyRangeArray(array);
         } else {
@@ -93,9 +514,9 @@ class RecordStream {
     }
 }
 
-// This stream implmenter works for POST requests
-class QueryResultStream {
-    private QueryResult[] currentEntries = [];
+// This stream implementer works for POST requests
+class DocumentQueryResultStream {
+    private Document[] currentEntries = [];
     private string continuationToken;
     int index = 0;
     private final http:Client httpClient;
@@ -110,9 +531,9 @@ class QueryResultStream {
         self.currentEntries = check self.fetchQueryResults();
     }
 
-    public isolated function next() returns @tainted record {| QueryResult value; |}|error? {
+    public isolated function next() returns @tainted record {| Document value; |}|error? {
         if(self.index < self.currentEntries.length()) {
-            record {| QueryResult value; |} singleRecord = {value: self.currentEntries[self.index]};
+            record {| Document value; |} singleRecord = {value: self.currentEntries[self.index]};
             self.index += 1;
             return singleRecord;
         }
@@ -120,13 +541,13 @@ class QueryResultStream {
         if (self.continuationToken != EMPTY_STRING) {
             self.index = 0;
             self.currentEntries = check self.fetchQueryResults();
-            record {| QueryResult value; |} singleRecord = {value: self.currentEntries[self.index]};
+            record {| Document value; |} singleRecord = {value: self.currentEntries[self.index]};
             self.index += 1;
             return singleRecord;
         }
     }
 
-    isolated function fetchQueryResults() returns @tainted QueryResult[]|Error {
+    isolated function fetchQueryResults() returns @tainted Document[]|Error {
         if (self.continuationToken != EMPTY_STRING) {
             self.request.setHeader(CONTINUATION_HEADER, self.continuationToken);
         }
@@ -137,7 +558,53 @@ class QueryResultStream {
         if (payload.Documents is json) {
             json[] array = let var load = payload.Documents in load is json ? <json[]>load : [];
             return convertToDocumentArray(array);
-        } else if (payload.Offers is json) {
+        } else {
+            return error PayloadValidationError(INVALID_RESPONSE_PAYLOAD_ERROR);
+        }
+    }
+}
+
+class OfferQueryResultStream {
+    private Offer[] currentEntries = [];
+    private string continuationToken;
+    int index = 0;
+    private final http:Client httpClient;
+    private final string path;
+    http:Request request;
+
+    isolated function  init(http:Client httpClient, string path, http:Request request) returns @tainted error? {
+        self.httpClient = httpClient;
+        self.path = path;
+        self.continuationToken = EMPTY_STRING;
+        self.request = request;
+        self.currentEntries = check self.fetchOfferQueryResults();
+    }
+
+    public isolated function next() returns @tainted record {| Offer value; |}|error? {
+        if(self.index < self.currentEntries.length()) {
+            record {| Offer value; |} singleRecord = {value: self.currentEntries[self.index]};
+            self.index += 1;
+            return singleRecord;
+        }
+        // This code block is for retrieving the next batch of records when the initial batch is finished.
+        if (self.continuationToken != EMPTY_STRING) {
+            self.index = 0;
+            self.currentEntries = check self.fetchOfferQueryResults();
+            record {| Offer value; |} singleRecord = {value: self.currentEntries[self.index]};
+            self.index += 1;
+            return singleRecord;
+        }
+    }
+
+    isolated function fetchOfferQueryResults() returns @tainted Offer[]|Error {
+        if (self.continuationToken != EMPTY_STRING) {
+            self.request.setHeader(CONTINUATION_HEADER, self.continuationToken);
+        }
+        http:Response response = check self.httpClient->post(self.path, self.request);
+        self.continuationToken = let var header = response.getHeader(CONTINUATION_HEADER) in header is string ? header :
+            EMPTY_STRING;
+        json payload = check handleResponse(response);
+        if (payload.Offers is json) {
             json[] array = let var load = payload.Offers in load is json ? <json[]>load : [];
             return convertToOfferArray(array);
         } else {
@@ -147,7 +614,7 @@ class QueryResultStream {
 }
 
 # Convert JSON array of database information in to an array of type `Database`.
-# 
+#
 # + sourceDatabaseArrayJsonObject - JSON object which contain the array of database information
 # + return - An array of type `Database`
 isolated function convertToDatabaseArray(json[] sourceDatabaseArrayJsonObject) returns Database[] {
@@ -160,7 +627,7 @@ isolated function convertToDatabaseArray(json[] sourceDatabaseArrayJsonObject) r
 }
 
 # Convert JSON array of container information in to an array of type `Container`.
-# 
+#
 # + sourceContainerArrayJsonObject - JSON object which contain the array of container information
 # + return - An array of type `Container`
 isolated function convertToContainerArray(json[] sourceContainerArrayJsonObject) returns Container[] {
@@ -173,7 +640,7 @@ isolated function convertToContainerArray(json[] sourceContainerArrayJsonObject)
 }
 
 # Convert JSON array of document information in to an array of type `Document`.
-# 
+#
 # + sourceDocumentArrayJsonObject - JSON object which contain the array of document information
 # + return - An array of type `Document`
 isolated function convertToDocumentArray(json[] sourceDocumentArrayJsonObject) returns Document[] {
@@ -186,10 +653,10 @@ isolated function convertToDocumentArray(json[] sourceDocumentArrayJsonObject) r
 }
 
 # Convert JSON array of stored procedure information in to an array of type `StoredProcedure`.
-# 
+#
 # + sourceStoredProcedureArrayJsonObject - JSON object which contain the array of stored procedure information
 # + return - An array of type `StoredProcedure`
-isolated function convertToStoredProcedureArray(json[] sourceStoredProcedureArrayJsonObject) returns 
+isolated function convertToStoredProcedureArray(json[] sourceStoredProcedureArrayJsonObject) returns
                                                 StoredProcedure[] {
     StoredProcedure[] storedProcedures = [];
     foreach json storedProcedureObject in sourceStoredProcedureArrayJsonObject {
@@ -200,7 +667,7 @@ isolated function convertToStoredProcedureArray(json[] sourceStoredProcedureArra
 }
 
 # Convert JSON array of user defined function information in to an array of type `UserDefinedFunction`.
-# 
+#
 # + sourceUdfArrayJsonObject - JSON object which contain the array of user defined function information
 # + return - An array of type `UserDefinedFunction`
 isolated function convertsToUserDefinedFunctionArray(json[] sourceUdfArrayJsonObject) returns UserDefinedFunction[] {
@@ -213,7 +680,7 @@ isolated function convertsToUserDefinedFunctionArray(json[] sourceUdfArrayJsonOb
 }
 
 # Convert JSON array of trigger information in to an array of type `Trigger`.
-# 
+#
 # + sourceTriggerArrayJsonObject - JSON object which contain the array of trigger information
 # + return - An array of type `Trigger`
 isolated function convertToTriggerArray(json[] sourceTriggerArrayJsonObject) returns Trigger[] {
@@ -226,7 +693,7 @@ isolated function convertToTriggerArray(json[] sourceTriggerArrayJsonObject) ret
 }
 
 # Convert JSON array of user information in to an array of type `User`.
-# 
+#
 # + sourceUserArrayJsonObject - JSON object which contain the array of user information
 # + return - An array of type `User`
 isolated function convertToUserArray(json[] sourceUserArrayJsonObject) returns User[] {
@@ -239,7 +706,7 @@ isolated function convertToUserArray(json[] sourceUserArrayJsonObject) returns U
 }
 
 # Convert JSON array of permission information in to an array of type `Permission`.
-# 
+#
 # + sourcePermissionArrayJsonObject - JSON object which contain the array of permission information
 # + return - An array of type `Permission`
 isolated function convertToPermissionArray(json[] sourcePermissionArrayJsonObject) returns Permission[] {
@@ -252,7 +719,7 @@ isolated function convertToPermissionArray(json[] sourcePermissionArrayJsonObjec
 }
 
 # Convert JSON array of offer infromation in to an array of type `Offer`.
-# 
+#
 # + sourceOfferArrayJsonObject - JSON object which contain the array of offer information
 # + return - An array of type `Offer`
 isolated function convertToOfferArray(json[] sourceOfferArrayJsonObject) returns Offer[] {
@@ -265,10 +732,10 @@ isolated function convertToOfferArray(json[] sourceOfferArrayJsonObject) returns
 }
 
 # Convert JSON array of partition key ranges in to an array of type `PartitionKeyRange`.
-# 
+#
 # + sourcePrtitionKeyArrayJsonObject - JSON object which contain the array of partition key range information
 # + return - An array of type `PartitionKeyRange`
-isolated function convertToPartitionKeyRangeArray(json[] sourcePrtitionKeyArrayJsonObject) returns 
+isolated function convertToPartitionKeyRangeArray(json[] sourcePrtitionKeyArrayJsonObject) returns
                                                   PartitionKeyRange[] {
     PartitionKeyRange[] partitionKeyRangesArray = [];
     foreach json jsonPartitionKey in sourcePrtitionKeyArrayJsonObject {

--- a/cosmosdb/tests/test.bal
+++ b/cosmosdb/tests/test.bal
@@ -166,8 +166,8 @@ function testListAllDatabases() {
     log:printInfo("ACTION : listAllDatabases()");
 
     var result = azureCosmosManagementClient->listDatabases();
-    if (result is stream<Data, error>) {
-        error? e = result.forEach(isolated function (Data queryResult) {
+    if (result is stream<Database, error>) {
+        error? e = result.forEach(isolated function (Database queryResult) {
             log:printInfo(queryResult.toString());
         });     
     } else {
@@ -286,8 +286,8 @@ function testGetAllContainers() {
     log:printInfo("ACTION : getAllContainers()");
 
     var result = azureCosmosManagementClient->listContainers(databaseId);
-    if (result is stream<Data, error>) {
-        error? e = result.forEach(isolated function (Data queryResult) {
+    if (result is stream<Container, error>) {
+        error? e = result.forEach(isolated function (Container queryResult) {
             log:printInfo(queryResult.toString());
         }); 
     } else {
@@ -435,8 +435,8 @@ function testGetDocumentList() {
     log:printInfo("ACTION : getDocumentList()");
 
     var result = azureCosmosClient->getDocumentList(databaseId, containerId);
-    if (result is stream<Data, error>) {
-        error? e = result.forEach(isolated function (Data queryResult) {
+    if (result is stream<Document, error>) {
+        error? e = result.forEach(isolated function (Document queryResult) {
             log:printInfo(queryResult.toString());
         }); 
     } else {
@@ -458,8 +458,8 @@ function testGetDocumentListWithRequestOptions() {
         partitionKeyRangeId: "0"
     };
     var result = azureCosmosClient->getDocumentList(databaseId, containerId, options);
-    if (result is stream<Data, error>) {
-        error? e = result.forEach(isolated function (Data queryResult) {
+    if (result is stream<Document, error>) {
+        error? e = result.forEach(isolated function (Document queryResult) {
             log:printInfo(queryResult.toString());
         }); 
     } else {
@@ -516,8 +516,8 @@ function testQueryDocuments() {
     string query = string `SELECT * FROM ${container.id.toString()} f WHERE f.Address.City = 'NY'`;
 
     var result = azureCosmosClient->queryDocuments(databaseId, containerId, query, options);
-    if (result is stream<QueryResult, error>) {
-        error? e = result.forEach(isolated function (QueryResult queryResult) {
+    if (result is stream<Document, error>) {
+        error? e = result.forEach(isolated function (Document queryResult) {
             log:printInfo(queryResult.toString());
         }); 
     } else {
@@ -539,8 +539,8 @@ function testQueryDocumentsWithRequestOptions() {
     };
 
     var result = azureCosmosClient->queryDocuments(databaseId, containerId, query, options);
-    if (result is stream<QueryResult, error>) {
-        error? e = result.forEach(isolated function (QueryResult queryResult) {
+    if (result is stream<Document, error>) {
+        error? e = result.forEach(isolated function (Document queryResult) {
             log:printInfo(queryResult.toString());
         }); 
     } else {
@@ -638,8 +638,8 @@ function testGetAllStoredProcedures() {
     log:printInfo("ACTION : getAllStoredProcedures()");
 
     var result = azureCosmosClient->listStoredProcedures(databaseId, containerId);
-    if (result is stream<Data, error>) {
-        error? e = result.forEach(isolated function (Data queryResult) {
+    if (result is stream<StoredProcedure, error>) {
+        error? e = result.forEach(isolated function (StoredProcedure queryResult) {
             log:printInfo(queryResult.toString());
         }); 
     } else {
@@ -726,8 +726,8 @@ function testListAllUDF() {
     log:printInfo("ACTION : listAllUDF()");
 
     var result = azureCosmosManagementClient->listUserDefinedFunctions(databaseId, containerId);
-    if (result is stream<Data, error>) {
-        error? e = result.forEach(isolated function (Data queryResult) {
+    if (result is stream<UserDefinedFunction, error>) {
+        error? e = result.forEach(isolated function (UserDefinedFunction queryResult) {
             log:printInfo(queryResult.toString());
         });    
     } else {
@@ -851,8 +851,8 @@ function testListTriggers() {
     log:printInfo("ACTION : listTriggers()");
 
     var result = azureCosmosManagementClient->listTriggers(databaseId, containerId);
-    if (result is stream<Data, error>) {
-        error? e = result.forEach(isolated function (Data queryResult) {
+    if (result is stream<Trigger, error>) {
+        error? e = result.forEach(isolated function (Trigger queryResult) {
             log:printInfo(queryResult.toString());
         }); 
     } else {
@@ -939,8 +939,8 @@ function testListUsers() {
     log:printInfo("ACTION : listUsers()");
 
     var result = azureCosmosManagementClient->listUsers(databaseId);
-    if (result is stream<Data, error>) {
-        error? e = result.forEach(isolated function (Data queryResult) {
+    if (result is stream<User, error>) {
+        error? e = result.forEach(isolated function (User queryResult) {
             log:printInfo(queryResult.toString());
         }); 
     } else {
@@ -1046,8 +1046,8 @@ function testListPermissions() {
     log:printInfo("ACTION : listPermissions()");
 
     var result = azureCosmosManagementClient->listPermissions(databaseId, newUserId);
-    if (result is stream<Data, error>) {
-        error? e = result.forEach(isolated function (Data queryResult) {
+    if (result is stream<Permission, error>) {
+        error? e = result.forEach(isolated function (Permission queryResult) {
             log:printInfo(queryResult.toString());
         }); 
     } else {
@@ -1096,12 +1096,12 @@ function testListOffers() {
     log:printInfo("ACTION : listOffers()");
 
     var result = azureCosmosManagementClient->listOffers();
-    if (result is stream<Data, error>) {
-        record {|Data value;|}|error? offer = result.next();
-        if (offer is record {|Data value;|}) {
+    if (result is stream<Offer, error>) {
+        record {|Offer value;|}|error? offer = result.next();
+        if (offer is record {|Offer value;|}) {
             offerId = <@untainted>offer?.value?.id;
             runtime:sleep(1);
-            resourceId = offer?.value?.resourceId;
+            resourceId = <@untainted>offer?.value?.resourceId;
         } else {
             log:printInfo("Empty stream");
         }

--- a/cosmosdb/types.bal
+++ b/cosmosdb/types.bal
@@ -386,10 +386,5 @@ public type ResourceDeleteOptions record {|
 type Options DocumentCreateOptions|DocumentReplaceOptions|DocumentListOptions|ResourceReadOptions|
     ResourceQueryOptions|ResourceDeleteOptions;
 
-# A Union type containing `Document`, `Database`, `Container`, `StoredProcedure`, `UserDefinedFunction`, `Trigger`, 
-# `User`, `Permission`, `Offer` and `PartitionKeyRange`
-public type Data Document|Database|Container|StoredProcedure|UserDefinedFunction|Trigger|User|Permission|Offer|
-    PartitionKeyRange;
-
 # A Union type containing `Document`, `Offer`
 public type QueryResult Document|Offer;


### PR DESCRIPTION
## Purpose
> $subject

## Goals
> The current implementation of Cosmos DB connector, stream return types provide a Union type called `Data` in each operation which must be then cast to the relevant type by the user. To fix this the return types of streams must contain individual types inside.

## Approach
> The current stream implementer class must be repeated for each type. This is because the Stream<Data> output cannot be cast to get the specific type inside the ballerina code. So they must be handled separately using separate classes

## Release note
> Change the stream types to return single record type inside it. To enhance user experience in using the connector

## Documentation
https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/blob/main/README.md

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Samples related to list operations can be found here
https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/tree/main/cosmosdb/samples

## Test environment
> Ubuntu 20.04 LTS
> Java 11
> Ballerina SL Beta 1
 