### PR TITLE
Bump versions for slbeta3 in master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,7 @@ on: [push]
 
 jobs:
     build:
-
         runs-on: ubuntu-latest
-
         steps:
             - uses: actions/checkout@v2
             - name: Ballerina Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,7 @@ on:
 
 jobs:
     build:
-
         runs-on: ubuntu-latest
-
         steps:
             - uses: actions/checkout@v2
             - name: Ballerina Build
@@ -27,4 +25,5 @@ jobs:
                   args:
                       push 
               env:
+                  WORKING_DIR: ./cosmosdb
                   BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For more information, see module(s).
    > **Note:** Set the JAVA_HOME environment variable to the path name of the directory into which you installed
    JDK.
  
-2. Download and install [Ballerina Swan Lake Beta2](https://ballerina.io/)
+2. Download and install [Ballerina Swan Lake Beta3](https://ballerina.io/)
  
 ### Building the source
  

--- a/cosmosdb/Dependencies.toml
+++ b/cosmosdb/Dependencies.toml
@@ -1,36 +1,34 @@
 [[dependency]]
 org = "ballerina"
 name = "regex"
-version = "0.7.0-beta.2"
+version = "0.7.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "url"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "http"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "crypto"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "time"
-version = "2.0.0-beta.2"
+version = "2.0.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "log"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "os"
-version = "0.8.0-beta.2"
-
-
+version = "0.8.0-beta.3"

--- a/cosmosdb/Package.md
+++ b/cosmosdb/Package.md
@@ -7,7 +7,7 @@ The `azure_cosmosdb` is a [Ballerina](https://ballerina.io/) connector for Azure
 ### Compatibility
 |                      | Version                    |
 |----------------------|----------------------------|
-| Ballerina Language   | Ballerina Swan Lake Beta2  | 
+| Ballerina Language   | Ballerina Swan Lake Beta3  | 
 | Cosmos DB (SQL)API   | 2018-12-31                 |
 
 ## Report issues


### PR DESCRIPTION
## Purpose
- Bump version to slbeta3 in Dependencies.toml, README.md and Package.md

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 11
Ballerina SLBeta3-SNAPSHOT
