### PR TITLE
Add failure notification for weekly build

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -17,24 +17,6 @@ jobs:
             # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
             - uses: actions/checkout@v2
 
-            # Set up Java Environment
-            - name: Set up JDK 11
-              uses: actions/setup-java@v1
-              with:
-                java-version: 11
-            
-            # Grant execute permission to the gradlew script
-            - name: Grant execute permission for gradlew
-              run: chmod +x gradlew
-
-            # Build the project with Gradle
-            - name: Build with Gradle
-              env:
-                packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
-                packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
-                JAVA_OPTS: -DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true
-              run: |
-                ./gradlew build
             # Build the ballerina project
             - name: Ballerina Build
               uses: ballerina-platform/ballerina-action/@nightly
@@ -42,7 +24,6 @@ jobs:
                   args:
                       build -c --skip-tests ./cosmosdb
               env:
-                JAVA_HOME: /usr/lib/jvm/default-jvm
                 BASE_URL: ${{ secrets.BASE_URL }}
                 MASTER_OR_RESOURCE_TOKEN: ${{ secrets.MASTER_OR_RESOURCE_TOKEN }}
 

--- a/.github/workflows/weekly-build.yml
+++ b/.github/workflows/weekly-build.yml
@@ -17,24 +17,6 @@ jobs:
             # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
             - uses: actions/checkout@v2
 
-            # Set up Java Environment
-            - name: Set up JDK 11
-              uses: actions/setup-java@v1
-              with:
-                java-version: 11
-            
-            # Grant execute permission to the gradlew script
-            - name: Grant execute permission for gradlew
-              run: chmod +x gradlew
-
-            # Build the project with Gradle
-            - name: Build with Gradle
-              env:
-                packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
-                packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
-                JAVA_OPTS: -DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true
-              run: |
-                ./gradlew build
             # Build the ballerina project
             - name: Ballerina Build
               uses: ballerina-platform/ballerina-action/@nightly
@@ -42,6 +24,19 @@ jobs:
                   args:
                       build -c ./cosmosdb
               env:
-                JAVA_HOME: /usr/lib/jvm/default-jvm
                 BASE_URL: ${{ secrets.BASE_URL }}
                 MASTER_OR_RESOURCE_TOKEN: ${{ secrets.MASTER_OR_RESOURCE_TOKEN }}
+
+            # Send notification when build fails
+            - name: Notify failure
+              if: ${{ failure() }}
+              run: |
+                curl \
+                -X POST 'https://chat.googleapis.com/v1/spaces/${{secrets.BALLERINA_CHAT_ID}}/messages?key=${{secrets.BALLERINA_CHAT_KEY}}&token=${{secrets.BALLERINA_CHAT_TOKEN}}' \
+                --header 'Content-Type: application/json' \
+                -d '{"text": "*module-ballerinax-azure-cosmosdb* build failure \nPlease visit <https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/actions/workflows/weekly-build.yml|the weekly build page> for more information"}'
+                curl \
+                -X POST 'https://chat.googleapis.com/v1/spaces/${{secrets.CONNECTOR_CHAT_ID}}/messages?key=${{secrets.CONNECTOR_CHAT_KEY}}&token=${{secrets.CONNECTOR_CHAT_TOKEN}}' \
+                --header 'Content-Type: application/json' \
+                -d '{"text": "*module-ballerinax-azure-cosmosdb* build failure \nPlease visit <https://github.com/ballerina-platform/module-ballerinax-azure-cosmosdb/actions/workflows/weekly-build.yml|the weekly build page> for more information"}'
+                


### PR DESCRIPTION
## Purpose
- Add failure notification for weekly build
- Remove gradle related steps as they are not necessary in weekly and daily builds

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 11
Ballerina SLBeta3
