### PR TITLE
Ignore CI build for automated version update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - "automated/dependency_version_update"
+      - "automated/dependency_version_update_tmp"
 
 jobs:
     build:


### PR DESCRIPTION
# Description
Ignore CI build for automated version update to avoid multiple workflows running at the same time.

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
