### PR TITLE
[2201.4.1] Exclude reactor/netty from the jar

### DIFF
--- a/cosmosdb-native/build.gradle
+++ b/cosmosdb-native/build.gradle
@@ -42,6 +42,6 @@ jar {
         'io/netty/channel/group/**', 'io/netty/channel/local/**', 'io/netty/channel/embedded/**', 
         'io/netty/channel/oio/**', 'io/netty/channel/internal/**', 'io/netty/bootstrap/**', 'io/netty/util/**', 
         'io/netty/buffer/**', 'javax/activation/**', 'org/codehaus/stax2/**', 'org/HdrHistogram/**', 'com/ctc/wstx/**', 
-        'org/slf4j/**', 'io/netty/**'
+        'org/slf4j/**', 'io/netty/**', 'reactor/netty/**'
     }
 }


### PR DESCRIPTION
# Description
- Exclude reactor/netty from the jar
