### PR TITLE
Remove scanning of example JARs in the Trivy workflow

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew build -x check -x test
+        run: ./gradlew build -x check -x test -x :azure-cosmosdb-examples:build
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,4 +11,4 @@ researchgateReleaseVersion=2.8.0
 testngVersion=7.4.0
 
 ballerinaLangVersion=2201.7.0
-azureCosmosVersion=4.49.0
+azureCosmosVersion=4.48.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,4 +11,4 @@ researchgateReleaseVersion=2.8.0
 testngVersion=7.4.0
 
 ballerinaLangVersion=2201.7.0
-azureCosmosVersion=4.48.1
+azureCosmosVersion=4.49.0


### PR DESCRIPTION
# Description

The PR removes the building of examples in the Trivy scan workflow, so only the module-added dependencies are scanned for the check.

Related to https://github.com/ballerina-platform/ballerina-extended-library/issues/584

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
