### PR TITLE
Patch function for cosmosdb added

### DIFF
--- a/ballerina/client_endpoint.bal
+++ b/ballerina/client_endpoint.bal
@@ -165,6 +165,26 @@ public isolated client class DataPlaneClient {
         'class: "io.ballerinax.cosmosdb.DataplaneClient"
     } external;
 
+    // Patches a document.
+    // 
+    // + databaseId - ID of the database to which the container belongs
+    // + containerId - ID of the container which contains the document
+    // + documentId - ID of the document
+    // + partitionKey - The specific value related to the partition key field of the container
+    // + operations - An array of PatchOperation records specifying the operations to perform
+    // + requestOptions - Optional request options which can include a filterPredicate for conditional patching
+    // + return - DocumentResponse if successful, or error if failed
+    @display {label: "Patch Document"}
+    remote isolated function patchDocument(@display {label: "Database ID"} string databaseId,
+                                          @display {label: "Container ID"} string containerId,
+                                          @display {label: "Document ID"} string documentId,
+                                          @display {label: "Partition Key"} string partitionKey,
+                                          @display {label: "Patch Operations"} PatchOperation[] operations,
+                                          @display {label: "Optional Header Parameters"} PatchRequestOptions? requestOptions = ()) 
+                                          returns cosmosdb:DocumentResponse|error = @java:Method {
+        'class: "io.ballerinax.cosmosdb.DataplaneClient"
+    } external;
+
     # Creates a new stored procedure. 
     #
     # + databaseId - ID of the database to which the container belongs to

--- a/ballerina/client_endpoint.bal
+++ b/ballerina/client_endpoint.bal
@@ -165,15 +165,15 @@ public isolated client class DataPlaneClient {
         'class: "io.ballerinax.cosmosdb.DataplaneClient"
     } external;
 
-    // Patches a document.
-    // 
-    // + databaseId - ID of the database to which the container belongs
-    // + containerId - ID of the container which contains the document
-    // + documentId - ID of the document
-    // + partitionKey - The specific value related to the partition key field of the container
-    // + operations - An array of PatchOperation records specifying the operations to perform
-    // + requestOptions - Optional request options which can include a filterPredicate for conditional patching
-    // + return - DocumentResponse if successful, or error if failed
+    # Patches a document.
+    # 
+    # + databaseId - ID of the database to which the container belongs
+    # + containerId - ID of the container which contains the document
+    # + documentId - ID of the document
+    # + partitionKey - The specific value related to the partition key field of the container
+    # + operations - An array of PatchOperation records specifying the operations to perform
+    # + requestOptions - Optional request options which can include a filterPredicate for conditional patching
+    # + return - DocumentResponse if successful, or error if failed
     @display {label: "Patch Document"}
     remote isolated function patchDocument(@display {label: "Database ID"} string databaseId,
                                           @display {label: "Container ID"} string containerId,

--- a/examples/data-operations/documents/patch_document.bal
+++ b/examples/data-operations/documents/patch_document.bal
@@ -1,0 +1,46 @@
+import ballerina/log;
+import ballerina/os;
+import ballerinax/azure_cosmosdb as cosmosdb;
+
+cosmosdb:ConnectionConfig config = {
+    baseUrl: os:getEnv("BASE_URL"),
+    primaryKeyOrResourceToken: os:getEnv("MASTER_OR_RESOURCE_TOKEN")
+};
+
+cosmosdb:DataPlaneClient azureCosmosClient = check new (config);
+
+public function main() returns error? {
+    string databaseId = "my_database";
+    string containerId = "my_container";
+    string documentId = "my_document";
+    int partitionKeyValue = 0; // Adjust this according to your partition key strategy
+
+    json patchOperations = {
+        "operations": [
+            {
+                "op": "set",
+                "path": "/FirstName",
+                "value": "Alan Updated"
+            },
+            {
+                "op": "add",
+                "path": "/NewField",
+                "value": "New Value"
+            }
+        ]
+    };
+
+    // Remove the condition as it may not be applicable directly in the patchDocument call.
+    // You might want to check if your connector supports conditional updates in a different manner.
+
+    log:printInfo("Patching a document in Cosmos DB");
+
+    // Call to patchDocument should not include the condition directly
+    var response = azureCosmosClient->patchDocument(databaseId, containerId, documentId, patchOperations, partitionKeyValue);
+
+    if (response is cosmosdb:DocumentResponse) {
+        log:printInfo("Document patched successfully: " + response.toString());
+    } else {
+        log:printError("Failed to patch document: " + response.message());
+    }
+}

--- a/examples/data-operations/documents/patch_document.bal
+++ b/examples/data-operations/documents/patch_document.bal
@@ -36,11 +36,6 @@ public function main() returns error? {
     log:printInfo("Patching a document in Cosmos DB");
 
     // Call to patchDocument should not include the condition directly
-    var response = azureCosmosClient->patchDocument(databaseId, containerId, documentId, patchOperations, partitionKeyValue);
-
-    if (response is cosmosdb:DocumentResponse) {
-        log:printInfo("Document patched successfully: " + response.toString());
-    } else {
-        log:printError("Failed to patch document: " + response.message());
-    }
+    cosmosdb:DocumentResponse response = check azureCosmosClient->patchDocument(databaseId, containerId, documentId, patchOperations, partitionKeyValue);
+    log:printInfo("Document patched successfully: " + response.toString());
 }

--- a/native/src/main/java/io/ballerinax/cosmosdb/DataplaneClient.java
+++ b/native/src/main/java/io/ballerinax/cosmosdb/DataplaneClient.java
@@ -145,8 +145,8 @@ public class DataplaneClient {
     }
 
     public static Object patchDocument(Environment env, BString databaseId, BString containerId,
-                                        BString documentId, Object partitionKey, BMap document,
-                                        Object requestOptions) {
+                                       BString documentId, Object partitionKey, BMap document,
+                                       Object requestOptions) {
         try {
             CosmosContainer container = getContainer(databaseId, containerId);
             Object documentObject = objectMapper.readValue(document.toString(), Object.class);

--- a/native/src/main/java/io/ballerinax/cosmosdb/DataplaneClient.java
+++ b/native/src/main/java/io/ballerinax/cosmosdb/DataplaneClient.java
@@ -144,6 +144,24 @@ public class DataplaneClient {
         }
     }
 
+    public static Object patchDocument(Environment env, BString databaseId, BString containerId,
+                                        BString documentId, Object partitionKey, BMap document,
+                                        Object requestOptions) {
+        try {
+            CosmosContainer container = getContainer(databaseId, containerId);
+            Object documentObject = objectMapper.readValue(document.toString(), Object.class);
+            CosmosPatchItemRequestOptions patchOptions = new CosmosPatchItemRequestOptions();
+            if (requestOptions != null) {
+                patchOptions = createRequestOptions(requestOptions);
+            }
+            CosmosPatchItemResponse response = container.patchItem(documentId.getValue(),
+                    createPartitionKey(partitionKey), documentObject, patchOptions);
+            return createDocumentResponse(response);
+        } catch (Exception e) {
+            return BallerinaErrorGenerator.createBallerinaDatabaseError(e);
+        }
+    }
+
     public static Object getDocumentList(Environment env, BObject client, BString databaseId, BString containerId,
                                          Object partitionKey, Object queryOptions, BTypedesc recordType) {
         try {


### PR DESCRIPTION
# Description

This update implements a function to patch a document in Azure Cosmos DB using the Ballerina programming language. The function allows for modifying existing fields and adding new fields to the specified document.

Fixes https://github.com/ballerina-platform/ballerina-library/issues/4972#issue-1946801244



One line release note: 
- Implemented patch operation for updating specific fields in a document in Azure Cosmos DB using Ballerina.

## Type of change

Please delete options that are not relevant.

- 
- [✓ ] New feature (non-breaking change which adds functionality)


# Checklist:

### Security checks
 - [ ✓] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [✓ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
